### PR TITLE
Add White Portal Settings page + generic channel map

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,11 +42,12 @@ SESSION_SECRET_KEY=change-me-to-a-long-random-string
 # Access the rule management panel at: http://localhost:8000/web/
 
 # ── Async Session Features ────────────────────────────────────────────────────
-# Discord role name whose members can use /retcon (default: GM)
-ADMIN_ROLE_NAME=GM
+# These settings are now managed at runtime via White Portal → Settings page.
+# The values below serve as startup defaults only if not yet configured in the DB.
+#
+# ADMIN_ROLE_NAME: Discord role whose members can use /retcon, /sic, /switch_world
+# (default: GM — override in White Portal → Settings)
 
-# Discord channel IDs for location-based channel manipulation (optional)
-DUNGEON_CHANNEL_ID=
-PRISON_CHANNEL_ID=
-HOSPITAL_CHANNEL_ID=
-MAIN_CHANNEL_ID=
+# Channel mappings are configured via White Portal → Settings → Channel Map.
+# Use any zone names that fit your game system (e.g. med_bay, brig, tavern).
+# No channel IDs are needed here — add them after first boot in the web UI.

--- a/db/migrations/011_settings_channels.sql
+++ b/db/migrations/011_settings_channels.sql
@@ -1,0 +1,15 @@
+-- Migration 011: Seed runtime-configurable system settings
+-- These values are managed via the White Portal → Settings page.
+-- ON CONFLICT DO NOTHING preserves any values already set by an operator.
+
+INSERT INTO system_settings (key, value) VALUES
+  ('channel_map',         '{}'),
+  ('admin_role_name',     '"GM"'),
+  ('session_ttl_seconds', '3600'),
+  ('gemini_model',        '"gemini-1.5-pro"'),
+  ('ollama_model',        '"mistral:7b-instruct"'),
+  ('claude_model',        '"claude-sonnet-4-6"'),
+  ('cloud_provider',      '"gemini"'),
+  ('gemini_api_key',      '""'),
+  ('claude_api_key',      '""')
+ON CONFLICT (key) DO NOTHING;

--- a/discord-bot/bot.py
+++ b/discord-bot/bot.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 import uuid
 from typing import Any
 
@@ -46,13 +47,34 @@ ORCHESTRATOR_URL  = os.environ["ORCHESTRATOR_URL"]
 DISCORD_BOT_TOKEN = os.environ["DISCORD_BOT_TOKEN"]
 _MAX_DOWNLOAD_BYTES = 200 * 1024 * 1024
 
-# ── Channel Key → Discord Channel ID mapping (configured via env vars) ────────
-_CHANNEL_IDS: dict[str, int | None] = {
-    "dungeon":  int(os.environ["DUNGEON_CHANNEL_ID"])  if os.environ.get("DUNGEON_CHANNEL_ID")  else None,
-    "prison":   int(os.environ["PRISON_CHANNEL_ID"])   if os.environ.get("PRISON_CHANNEL_ID")   else None,
-    "hospital": int(os.environ["HOSPITAL_CHANNEL_ID"]) if os.environ.get("HOSPITAL_CHANNEL_ID") else None,
-    "main":     int(os.environ["MAIN_CHANNEL_ID"])     if os.environ.get("MAIN_CHANNEL_ID")     else None,
-}
+# ── Channel Map — generic zone-key → Discord channel ID ──────────────────────
+# Populated at runtime from the orchestrator's /api/settings/channels endpoint.
+# Admins configure zone names (e.g. "med_bay", "brig") via White Portal → Settings.
+# The cache is refreshed every _CHANNEL_MAP_TTL seconds so changes propagate
+# without a bot restart.
+
+_channel_map_cache:      dict[str, int] = {}
+_channel_map_fetched_at: float          = 0.0
+_CHANNEL_MAP_TTL: float                 = 60.0  # seconds between refreshes
+
+
+async def _get_channel_id(channel_key: str) -> int | None:
+    """Return the Discord channel ID for a zone key, refreshing the cache as needed."""
+    global _channel_map_cache, _channel_map_fetched_at
+    now = time.monotonic()
+    if now - _channel_map_fetched_at > _CHANNEL_MAP_TTL:
+        try:
+            resp = await bot.http_client.get("/api/settings/channels")
+            if resp.status_code == 200:
+                raw = resp.json()
+                _channel_map_cache = {
+                    k: int(v) for k, v in raw.items()
+                    if str(v).isdigit()
+                }
+                _channel_map_fetched_at = now
+        except Exception as exc:
+            logger.debug("Channel map refresh failed: %s", exc)
+    return _channel_map_cache.get(channel_key)
 
 # ── Outcome → embed colour ────────────────────────────────────────────────────
 OUTCOME_COLORS: dict[str, int] = {
@@ -569,10 +591,12 @@ async def _handle_channel_directive(
     """
     Grant or revoke the player's access to a semantic location channel.
 
-    "move_to"  → grant read-only access to dungeon/prison/hospital channel.
-    "restore"  → restore full send access to the main channel.
+    "move_to"  → grant read-only access to the target zone channel.
+    "restore"  → restore full send access to the main/home channel.
 
-    Channel IDs are mapped from env vars.  If a key is not configured,
+    Channel IDs are fetched from the orchestrator settings API (cached 60 s).
+    Configure zone names in White Portal → Settings → Channel Map.
+    If a key is not configured,
     the directive is logged and skipped — no crash, no noise.
     Requires bot 'Manage Permissions' permission in the target channel.
     """
@@ -580,7 +604,7 @@ async def _handle_channel_directive(
     channel_key = directive.get("channel_key")
     reason_str  = directive.get("reason", "GM narrative directive")
 
-    target_id = _CHANNEL_IDS.get(channel_key)
+    target_id = await _get_channel_id(channel_key)
     if not target_id:
         logger.info(
             "Channel directive '%s' → '%s' skipped — env var not configured.",

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -1088,6 +1088,27 @@ async def get_sic_status() -> dict:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Settings API (consumed by the Discord bot)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@app.get(
+    "/api/settings/channels",
+    summary="Return the generic channel map for the Discord bot",
+    tags=["settings"],
+)
+async def api_settings_channels() -> dict:
+    """
+    Returns the channel_map system setting as a plain JSON object.
+    Keys are admin-defined zone labels (e.g. "med_bay", "brig");
+    values are Discord channel ID strings.
+
+    Called by the Discord bot every ~60 s to refresh its channel lookup
+    table without requiring an env-var edit or container restart.
+    """
+    return await db.get_system_setting("channel_map", default={})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Dynamic World / Genre Orchestration
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/orchestrator/routers/web_ui.py
+++ b/orchestrator/routers/web_ui.py
@@ -21,6 +21,10 @@ Pages:
   GET  /web/backchannel            – White Portal Admin Backchannel
   POST /web/backchannel/send       – Submit a new OOC directive
   POST /web/backchannel/cancel/{id} – Cancel a pending directive
+  GET  /web/settings               – Runtime settings (channel map, AI models, API keys)
+  POST /web/settings/general       – Save general + AI settings
+  POST /web/settings/channels/add  – Add or update a channel map entry
+  POST /web/settings/channels/delete – Remove a channel map entry
 """
 
 from __future__ import annotations
@@ -30,6 +34,8 @@ import logging
 import os
 import uuid
 from pathlib import Path
+
+import re
 
 from fastapi import APIRouter, BackgroundTasks, File, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -473,3 +479,117 @@ async def sandbox_page(request: Request):
         "flash_ok":  request.session.pop("flash_ok",  ""),
         "flash_err": request.session.pop("flash_err", ""),
     })
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Settings Page
+# ─────────────────────────────────────────────────────────────────────────────
+
+_CHANNEL_KEY_RE = re.compile(r'^[a-z0-9_]{1,32}$')
+
+
+@router.get("/settings", response_class=HTMLResponse)
+async def settings_page(request: Request):
+    db = _db(request)
+    channel_map     = await db.get_system_setting("channel_map",         default={})
+    admin_role_name = await db.get_system_setting("admin_role_name",     default="GM")
+    session_ttl     = await db.get_system_setting("session_ttl_seconds", default=3600)
+    gemini_model    = await db.get_system_setting("gemini_model",        default="gemini-1.5-pro")
+    ollama_model    = await db.get_system_setting("ollama_model",        default="mistral:7b-instruct")
+    claude_model    = await db.get_system_setting("claude_model",        default="claude-sonnet-4-6")
+    cloud_provider  = await db.get_system_setting("cloud_provider",      default="gemini")
+    gemini_api_key  = await db.get_system_setting("gemini_api_key",      default="")
+    claude_api_key  = await db.get_system_setting("claude_api_key",      default="")
+    return _tmpl(request).TemplateResponse("settings.html", {
+        "request":          request,
+        "page":             "settings",
+        "channel_map":      channel_map or {},
+        "admin_role_name":  admin_role_name or "GM",
+        "session_ttl":      session_ttl or 3600,
+        "gemini_model":     gemini_model or "gemini-1.5-pro",
+        "ollama_model":     ollama_model or "mistral:7b-instruct",
+        "claude_model":     claude_model or "claude-sonnet-4-6",
+        "cloud_provider":   cloud_provider or "gemini",
+        "gemini_api_key_set": bool(gemini_api_key),
+        "claude_api_key_set": bool(claude_api_key),
+        "flash_ok":  request.session.pop("flash_ok",  ""),
+        "flash_err": request.session.pop("flash_err", ""),
+    })
+
+
+@router.post("/settings/general", response_class=RedirectResponse)
+async def settings_general_save(
+    request:         Request,
+    admin_role_name: str = Form("GM"),
+    session_ttl:     int = Form(3600),
+    gemini_model:    str = Form("gemini-1.5-pro"),
+    ollama_model:    str = Form("mistral:7b-instruct"),
+    claude_model:    str = Form("claude-sonnet-4-6"),
+    cloud_provider:  str = Form("gemini"),
+    gemini_api_key:  str = Form(""),
+    claude_api_key:  str = Form(""),
+):
+    db = _db(request)
+    try:
+        await db.set_system_setting("admin_role_name",     admin_role_name.strip() or "GM")
+        await db.set_system_setting("session_ttl_seconds", max(60, session_ttl))
+        await db.set_system_setting("gemini_model",        gemini_model.strip() or "gemini-1.5-pro")
+        await db.set_system_setting("ollama_model",        ollama_model.strip() or "mistral:7b-instruct")
+        await db.set_system_setting("claude_model",        claude_model.strip() or "claude-sonnet-4-6")
+        if cloud_provider in ("gemini", "claude"):
+            await db.set_system_setting("cloud_provider", cloud_provider)
+        # Only update API keys if the field is non-empty (blank = keep existing)
+        if gemini_api_key.strip():
+            await db.set_system_setting("gemini_api_key", gemini_api_key.strip())
+        if claude_api_key.strip():
+            await db.set_system_setting("claude_api_key", claude_api_key.strip())
+        request.session["flash_ok"] = "Settings saved. API key changes take effect after restart."
+    except Exception as exc:
+        logger.exception("Settings save failed: %s", exc)
+        request.session["flash_err"] = str(exc)
+    return RedirectResponse("/web/settings", status_code=303)
+
+
+@router.post("/settings/channels/add", response_class=RedirectResponse)
+async def settings_channels_add(
+    request:     Request,
+    channel_key: str = Form(...),
+    channel_id:  str = Form(...),
+):
+    db = _db(request)
+    key = channel_key.strip().lower()
+    cid = channel_id.strip()
+    if not _CHANNEL_KEY_RE.match(key):
+        request.session["flash_err"] = (
+            "Channel key must be 1–32 lowercase letters, digits, or underscores."
+        )
+        return RedirectResponse("/web/settings", status_code=303)
+    if not cid.isdigit():
+        request.session["flash_err"] = "Channel ID must be a numeric Discord snowflake."
+        return RedirectResponse("/web/settings", status_code=303)
+    try:
+        channel_map = await db.get_system_setting("channel_map", default={}) or {}
+        channel_map[key] = cid
+        await db.set_system_setting("channel_map", channel_map)
+        request.session["flash_ok"] = f"Channel '{key}' → {cid} saved. Takes effect within 60 s."
+    except Exception as exc:
+        logger.exception("Channel map add failed: %s", exc)
+        request.session["flash_err"] = str(exc)
+    return RedirectResponse("/web/settings", status_code=303)
+
+
+@router.post("/settings/channels/delete", response_class=RedirectResponse)
+async def settings_channels_delete(
+    request:     Request,
+    channel_key: str = Form(...),
+):
+    db = _db(request)
+    try:
+        channel_map = await db.get_system_setting("channel_map", default={}) or {}
+        channel_map.pop(channel_key.strip(), None)
+        await db.set_system_setting("channel_map", channel_map)
+        request.session["flash_ok"] = f"Channel '{channel_key}' removed."
+    except Exception as exc:
+        logger.exception("Channel map delete failed: %s", exc)
+        request.session["flash_err"] = str(exc)
+    return RedirectResponse("/web/settings", status_code=303)

--- a/orchestrator/templates/base.html
+++ b/orchestrator/templates/base.html
@@ -226,6 +226,7 @@
     <a href="/web/backchannel" {% if page == 'backchannel' %}class="active"{% endif %}>🔮 Backchannel</a>
     <a href="/web/sandbox"    {% if page == 'sandbox'     %}class="active"{% endif %}>🔬 Sandbox</a>
     <a href="/web/telemetry"  {% if page == 'telemetry'   %}class="active"{% endif %}>📡 Telemetry</a>
+    <a href="/web/settings"  {% if page == 'settings'    %}class="active"{% endif %}>⚙ Settings</a>
   </div>
   <form method="post" action="/web/logout" style="margin-left:8px">
     <button type="submit" style="

--- a/orchestrator/templates/settings.html
+++ b/orchestrator/templates/settings.html
@@ -1,0 +1,216 @@
+{% extends "base.html" %}
+{% block title %}Settings{% endblock %}
+
+{% block content %}
+<style>
+  .settings-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 720px) { .settings-grid { grid-template-columns: 1fr; } }
+  .key-cell { font-family: 'Courier New', monospace; font-size: 12px; color: var(--gold); }
+  .id-cell  { font-family: 'Courier New', monospace; font-size: 12px; color: var(--text); }
+  .hint { font-size: 11px; color: var(--muted); margin-top: 6px; line-height: 1.5; }
+  input[type="number"] {
+    width: 100%; background: var(--bg); border: 1px solid var(--border);
+    color: var(--text); padding: 8px 12px; border-radius: var(--radius);
+    font-size: 13px; font-family: inherit; outline: none; transition: border-color 0.15s;
+  }
+  input[type="number"]:focus { border-color: var(--gold); }
+  input[type="password"] {
+    width: 100%; background: var(--bg); border: 1px solid var(--border);
+    color: var(--text); padding: 8px 12px; border-radius: var(--radius);
+    font-size: 13px; font-family: inherit; outline: none; transition: border-color 0.15s;
+  }
+  input[type="password"]:focus { border-color: var(--gold); }
+  .api-key-row { display: flex; gap: 8px; align-items: center; }
+  .api-key-row input { flex: 1; }
+  .configured-badge {
+    font-size: 10px; font-weight: 600; padding: 3px 8px; border-radius: 20px; white-space: nowrap;
+    background: rgba(76,175,120,0.12); color: var(--green); border: 1px solid rgba(76,175,120,0.2);
+  }
+  .not-set-badge {
+    font-size: 10px; font-weight: 600; padding: 3px 8px; border-radius: 20px; white-space: nowrap;
+    background: rgba(107,107,128,0.10); color: var(--muted); border: 1px solid var(--border);
+  }
+  .restart-note {
+    display: flex; align-items: center; gap: 8px;
+    background: rgba(201,168,76,0.06); border: 1px solid rgba(201,168,76,0.18);
+    border-radius: var(--radius); padding: 10px 14px;
+    font-size: 12px; color: var(--gold); margin-top: 16px;
+  }
+</style>
+
+<div class="page-header">
+  <h1>⚙ Settings</h1>
+  <p>Runtime configuration — changes take effect immediately unless marked otherwise.</p>
+</div>
+
+<div class="settings-grid">
+
+  {# ── Card 1: General ──────────────────────────────────────────────────────── #}
+  <div class="card">
+    <div class="card-header">
+      <span class="card-title">General</span>
+    </div>
+    <div class="card-body">
+      <form method="post" action="/web/settings/general">
+        <div class="form-row">
+          <label for="admin_role_name">Admin Role Name</label>
+          <input type="text" id="admin_role_name" name="admin_role_name"
+                 value="{{ admin_role_name }}" placeholder="GM" required>
+          <p class="hint">Discord role whose members can use <code>/retcon</code>, <code>/sic</code>, and <code>/switch_world</code>.</p>
+        </div>
+        <div class="form-row">
+          <label for="session_ttl">Session TTL (seconds)</label>
+          <input type="number" id="session_ttl" name="session_ttl"
+                 value="{{ session_ttl }}" min="60" step="60">
+          <p class="hint">How long a player session stays active without a new action.</p>
+        </div>
+        <div class="form-row">
+          <label for="cloud_provider">Cloud Storyteller</label>
+          <select id="cloud_provider" name="cloud_provider">
+            <option value="gemini" {% if cloud_provider == "gemini" %}selected{% endif %}>Gemini (Google)</option>
+            <option value="claude" {% if cloud_provider == "claude" %}selected{% endif %}>Claude (Anthropic)</option>
+          </select>
+          <p class="hint">Which cloud API handles Phase 4 narrative prose. Toggle the raw on/off switch on the <a href="/web/nodes" style="color:var(--gold)">Nodes</a> page.</p>
+        </div>
+
+        <div class="divider-label">AI Models</div>
+
+        <div class="form-row">
+          <label for="gemini_model">Gemini Model</label>
+          <input type="text" id="gemini_model" name="gemini_model"
+                 value="{{ gemini_model }}" placeholder="gemini-1.5-pro">
+        </div>
+        <div class="form-row">
+          <label for="ollama_model">Ollama Model</label>
+          <input type="text" id="ollama_model" name="ollama_model"
+                 value="{{ ollama_model }}" placeholder="mistral:7b-instruct">
+          <p class="hint">Default model for local adjudication nodes. Individual nodes can override this on the <a href="/web/nodes" style="color:var(--gold)">Nodes</a> page.</p>
+        </div>
+        <div class="form-row">
+          <label for="claude_model">Claude Model</label>
+          <input type="text" id="claude_model" name="claude_model"
+                 value="{{ claude_model }}" placeholder="claude-sonnet-4-6">
+        </div>
+
+        <div class="divider-label">API Keys</div>
+
+        <div class="form-row">
+          <label>Gemini API Key</label>
+          <div class="api-key-row">
+            <input type="password" name="gemini_api_key" placeholder="Leave blank to keep existing" autocomplete="new-password">
+            {% if gemini_api_key_set %}
+              <span class="configured-badge">● Configured</span>
+            {% else %}
+              <span class="not-set-badge">Not set</span>
+            {% endif %}
+          </div>
+        </div>
+        <div class="form-row">
+          <label>Claude API Key</label>
+          <div class="api-key-row">
+            <input type="password" name="claude_api_key" placeholder="Leave blank to keep existing" autocomplete="new-password">
+            {% if claude_api_key_set %}
+              <span class="configured-badge">● Configured</span>
+            {% else %}
+              <span class="not-set-badge">Not set</span>
+            {% endif %}
+          </div>
+        </div>
+
+        <div class="restart-note">
+          ⚠ API key changes are stored immediately but require a service restart to be loaded by the inference clients.
+        </div>
+
+        <div style="margin-top:20px">
+          <button type="submit" class="btn btn-gold">Save Settings</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  {# ── Card 2: Channel Map ─────────────────────────────────────────────────── #}
+  <div class="card">
+    <div class="card-header">
+      <span class="card-title">Channel Map</span>
+    </div>
+    <div class="card-body">
+      <p class="hint" style="margin-bottom:16px">
+        Map zone names to Discord channel IDs. Use any labels that fit your game system —
+        <code>med_bay</code>, <code>brig</code>, <code>tavern</code>, <code>dungeon</code>, etc.
+        The GM engine references these by key when directing players to a location.
+        Changes propagate to the bot within 60 seconds.
+      </p>
+
+      {% if channel_map %}
+      <div class="table-wrap" style="margin-bottom:20px">
+        <table>
+          <thead>
+            <tr>
+              <th>Zone Key</th>
+              <th>Channel ID</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for key, cid in channel_map.items() %}
+            <tr>
+              <td class="key-cell">{{ key }}</td>
+              <td class="id-cell">{{ cid }}</td>
+              <td style="text-align:right">
+                <form method="post" action="/web/settings/channels/delete" style="display:inline">
+                  <input type="hidden" name="channel_key" value="{{ key }}">
+                  <button type="submit" class="btn btn-danger btn-sm"
+                          onclick="return confirm('Remove channel \'{{ key }}\'?')">✕</button>
+                </form>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <div class="empty" style="padding:28px 16px">
+        <div class="empty-icon">📡</div>
+        <p>No channels configured yet. Add one below.</p>
+      </div>
+      {% endif %}
+
+      <div class="divider-label">Add / Update Entry</div>
+
+      <form method="post" action="/web/settings/channels/add">
+        <div class="row" style="align-items:flex-end;gap:8px">
+          <div class="form-row" style="flex:1;margin-bottom:0">
+            <label for="channel_key">Zone Key</label>
+            <input type="text" id="channel_key" name="channel_key"
+                   placeholder="e.g. med_bay" pattern="[a-z0-9_]{1,32}"
+                   title="Lowercase letters, digits and underscores only" required>
+          </div>
+          <div class="form-row" style="flex:1;margin-bottom:0">
+            <label for="channel_id">Discord Channel ID</label>
+            <input type="text" id="channel_id" name="channel_id"
+                   placeholder="e.g. 1234567890123456789"
+                   pattern="\d+" title="Numeric channel snowflake" required>
+          </div>
+          <div style="padding-bottom:0">
+            <button type="submit" class="btn btn-gold">Add</button>
+          </div>
+        </div>
+        <p class="hint" style="margin-top:8px">
+          Right-click any Discord channel → <em>Copy Channel ID</em> (enable Developer Mode in Discord settings first).
+        </p>
+      </form>
+
+      <div style="margin-top:20px; padding-top:16px; border-top:1px solid var(--border)">
+        <p class="hint">
+          <strong style="color:var(--text)">Startup-only settings</strong> — the following require
+          editing <code>.env</code> and restarting the stack:
+          <code>DISCORD_BOT_TOKEN</code>, <code>POSTGRES_PASSWORD</code>,
+          <code>REDIS_PASSWORD</code>, <code>LAVALINK_PASSWORD</code>,
+          <code>SESSION_SECRET_KEY</code>.
+        </p>
+      </div>
+    </div>
+  </div>
+
+</div>
+{% endblock %}


### PR DESCRIPTION
Replace hardcoded RPG-specific channel env vars (DUNGEON_CHANNEL_ID, PRISON_CHANNEL_ID, HOSPITAL_CHANNEL_ID, MAIN_CHANNEL_ID) with a generic, admin-defined channel map stored in system_settings and editable via the new White Portal → Settings page.

- db/migrations/011_settings_channels.sql: seed default rows for channel_map, admin_role_name, session_ttl_seconds, model names, cloud_provider, and api key placeholders in system_settings

- orchestrator/main.py: add GET /api/settings/channels endpoint so the Discord bot can fetch the channel map at runtime without a restart

- discord-bot/bot.py: replace static _CHANNEL_IDS dict (env-var backed) with _get_channel_id() async function that fetches from the orchestrator API and caches results for 60 s; _handle_channel_directive now awaits it

- orchestrator/routers/web_ui.py: add GET /settings, POST /settings/general, POST /settings/channels/add, POST /settings/channels/delete routes

- orchestrator/templates/settings.html: new two-column settings page with General card (admin role, session TTL, cloud provider, model names, API keys) and Channel Map card (generic key→snowflake table with add/delete)

- orchestrator/templates/base.html: add ⚙ Settings nav link

- .env.example: remove the four channel ID vars; replace with comment directing operators to the Settings page after first boot

https://claude.ai/code/session_012E6zYEHSFx1i6zNWEKEcUF