### PR TITLE
docs: sync README and CLAUDE.md with migrations 007-011 and Settings …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ discord-bot/
   voice_manager.py  Voice channel audio, ambient loops, TTS playback
 db/
   schema.sql        Core tables
-  migrations/       001–009 SQL migrations (latest: 009_admin_auth.sql)
+  migrations/       001–011 SQL migrations (latest: 011_settings_channels.sql)
 csv-sync/           CSV export worker
 media-proxy/        Static asset server (:8001)
 health-sentinel/    Flask sidecar on :58291 — reports busy/ok status
@@ -128,7 +128,7 @@ data/
 
 Core tables: `campaigns`, `characters`, `inventories`, `action_log`, `sessions`, `story_facts`, `story_entities`, `vehicles`, `vehicle_subsystems`, `node_registry`, `global_settings`, `gm_directives`, `downtime_tasks`, `player_presence`, `retcon_log`, `admin_accounts`.
 
-Always run new migrations as `db/migrations/0NN_<name>.sql`. Never modify existing migration files.
+Always run new migrations as `db/migrations/0NN_<name>.sql`. Never modify existing migration files. Latest migration: `011_settings_channels.sql`.
 
 ## TDR Compliance Notes (Step 15)
 
@@ -166,8 +166,13 @@ Optional: `CLAUDE_API_KEY` + `CLOUD_PROVIDER=claude` to switch narration from Ge
 - `POST /api/rulebook/ingest` — PDF upload
 - `POST /api/vision/analyse` — image analysis (Gemini Vision)
 - `POST /api/web/search` — web search (SerpAPI / DuckDuckGo)
+- `GET /api/settings/channels` — fetch runtime channel map (used by Discord bot at startup)
 - `WS /ws/telemetry` — live pipeline event stream
 - `GET /web/*` — White Portal admin panel
+  - `/web/settings` — runtime config: channel map, AI model selection, API keys
+  - `POST /web/settings/general` — save general + AI settings
+  - `POST /web/settings/channels/add` — add or update a channel map entry
+  - `POST /web/settings/channels/delete` — remove a channel map entry
 
 ## Development Branch
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,12 @@ RPG-Bot/
 │       ├── 003_vehicles_and_nodes.sql      # Vehicles, subsystems, node_registry
 │       ├── 004_node_roles_and_settings.sql # Role tags, global_settings
 │       ├── 005_node_latency.sql            # TTFT benchmarking columns
-│       └── 006_node_voice_profile.sql      # Per-node voice_id for TTS
+│       ├── 006_node_voice_profile.sql      # Per-node voice_id for TTS
+│       ├── 007_async_session_features.sql  # downtime_tasks, player_presence, retcon_log
+│       ├── 008_admin_backchannel.sql       # gm_directives, fair_play_mode seed
+│       ├── 009_admin_auth.sql              # admin_accounts (first-boot setup lock)
+│       ├── 010_rolling_vault.sql           # rolling_vault sliding context window
+│       └── 011_settings_channels.sql       # system_settings seed (channel map, model names)
 │
 ├── orchestrator/
 │   ├── main.py                             # FastAPI app, pipeline wiring, API endpoints
@@ -317,7 +322,7 @@ docker compose up -d
 docker compose exec ironclad-db psql -U ironclad -d ironclad \
   -f /docker-entrypoint-initdb.d/001_schema.sql
 # Then run each migration in order:
-# migrations 002 through 006
+# migrations 002 through 011
 
 # 5. Pull an Ollama model
 docker compose exec ironclad-ollama ollama pull mistral:7b-instruct
@@ -356,10 +361,8 @@ docker compose exec ironclad-ollama ollama pull mistral:7b-instruct
 | `TTS_CACHE_DIR` | `/tmp/ironclad_tts` | TTS audio cache directory |
 | `AMBIENT_VOLUME` | `0.25` | Ambient audio volume (0.0–1.0) |
 | `TTS_VOLUME` | `0.90` | TTS voice volume (0.0–1.0) |
-| `CHANNEL_DUNGEON` | — | Discord channel ID for dungeon location |
-| `CHANNEL_PRISON` | — | Discord channel ID for prison location |
-| `CHANNEL_HOSPITAL` | — | Discord channel ID for hospital location |
-| `CHANNEL_MAIN` | — | Discord channel ID for main game channel |
+
+> **Note:** Discord channel IDs (dungeon, prison, hospital, main, etc.) are no longer set via environment variables. They are managed at runtime through **White Portal → Settings → Channel Map**.
 
 ### Adding Ambient Audio
 
@@ -406,17 +409,22 @@ deploy:
 | `/act <action>` | Perform a narrative action (triggers full pipeline) |
 | Free-text in game channel | Same as `/act` — natural language input |
 | `/rulebook <pdf>` | Upload a PDF rulebook for ingestion |
+| `/worlds` | List all discovered worlds with tone and tags |
+| `/switch_world <name>` | Bind the campaign to a world (creates it if new) |
 
 ---
 
 ## Web Admin Panel
 
-Access the Rule Forge at `http://localhost:8000/web/`:
+Access the White Portal at `http://localhost:8000/web/`:
 
 - **Dashboard** — Campaign overview and system status
 - **Rules** — Manage active rulebook modules per campaign
 - **Lore** — Browse and manage story facts / world canon
 - **Log** — Action log viewer with full pipeline replay
+- **Nodes** — AI node registry and connection dashboard
+- **Backchannel** — White Portal admin directive interface (OOC GM commands)
+- **Settings** — Runtime configuration: channel map, AI model selection, API keys
 
 ---
 


### PR DESCRIPTION
…page

- Migration file tree in README extended from 006 to 011 (added 007_async_session_features, 008_admin_backchannel, 009_admin_auth, 010_rolling_vault, 011_settings_channels)
- Migration run step updated from "002–006" to "002–011"
- Stale channel env vars (CHANNEL_DUNGEON/PRISON/HOSPITAL/MAIN) replaced with a note that channel IDs are now managed via White Portal → Settings
- Web Admin Panel section updated: renamed to "White Portal", added Nodes, Backchannel, and Settings pages
- Discord Commands table updated: added /worlds and /switch_world
- CLAUDE.md: latest migration updated from 009 to 011; new Settings routes and GET /api/settings/channels endpoint documented

https://claude.ai/code/session_01CCTWunGMijkKthjAeoKDG6