### PR TITLE
[Issue #27] Add one-command install.sh and uninstall.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Ironclad GM — One-command installer
+# Usage: bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/RPG-Bot/main/install.sh)
+# =============================================================================
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+REPO_URL="https://github.com/Crashcart/RPG-Bot.git"
+REPO_DIR="RPG-Bot"
+
+log()   { echo -e "${GREEN}[\u2713]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[!]${NC} $*"; }
+error() { echo -e "${RED}[\u2717]${NC} $*" >&2; exit 1; }
+info()  { echo -e "${CYAN}[→]${NC} $*"; }
+
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║          Ironclad GM — Installer                     ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════════════════════╝${NC}"
+echo ""
+
+# =============================================================================
+# Step 1: Prerequisite checks
+# =============================================================================
+info "Checking prerequisites..."
+
+command -v docker &>/dev/null || error "Docker is not installed. See: https://docs.docker.com/get-docker/"
+command -v git    &>/dev/null || error "git is not installed."
+command -v curl   &>/dev/null || error "curl is not installed."
+
+if docker compose version &>/dev/null 2>&1; then
+    DC="docker compose"
+elif command -v docker-compose &>/dev/null; then
+    DC="docker-compose"
+else
+    error "Docker Compose not found. See: https://docs.docker.com/compose/install/"
+fi
+
+log "Prerequisites satisfied (using: $DC)"
+
+# =============================================================================
+# Step 2: Clone repo or detect existing checkout
+# =============================================================================
+if [[ ! -f "docker-compose.yml" ]]; then
+    info "Cloning repository into ./$REPO_DIR ..."
+    git clone "$REPO_URL" "$REPO_DIR"
+    cd "$REPO_DIR"
+    log "Cloned into $(pwd)"
+else
+    log "Already inside the RPG-Bot repository at $(pwd)"
+fi
+
+# =============================================================================
+# Step 3: Environment setup
+# =============================================================================
+if [[ -f ".env" ]]; then
+    warn ".env already exists — skipping environment setup. Edit it manually if needed."
+else
+    cp .env.example .env
+    info "Created .env from .env.example"
+    echo ""
+    echo "  Enter your credentials below. Press Enter to accept an auto-generated value."
+    echo ""
+
+    # Helper: generate a secure random hex string
+    _rand()   { openssl rand -hex 16 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(16))"; }
+    _secret() { openssl rand -hex 32 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(32))"; }
+
+    # Helper: prompt for a value and write it into .env via sed
+    # Usage: set_env KEY "Prompt text" secret|visible [default_value]
+    set_env() {
+        local key="$1" prompt="$2" mode="$3" default="${4:-}"
+        local value=""
+        if [[ "$mode" == "auto" ]]; then
+            sed -i "s|^${key}=.*|${key}=${default}|" .env
+            return
+        fi
+        if [[ "$mode" == "secret" ]]; then
+            read -r -s -p "  ${prompt}: " value </dev/tty; echo ""
+        else
+            read -r    -p "  ${prompt}: " value </dev/tty
+        fi
+        if [[ -z "$value" && -n "$default" ]]; then
+            value="$default"
+            echo "    (auto-generated)"
+        fi
+        if [[ -n "$value" ]]; then
+            sed -i "s|^${key}=.*|${key}=${value}|" .env
+        fi
+    }
+
+    set_env "DISCORD_BOT_TOKEN"      "Discord Bot Token (required)"                    "secret"
+    set_env "DISCORD_APPLICATION_ID" "Discord Application ID (required)"               "visible"
+    set_env "POSTGRES_PASSWORD"      "PostgreSQL password   [Enter to auto-generate]"  "secret"  "$(_rand)"
+    set_env "REDIS_PASSWORD"         "Redis password        [Enter to auto-generate]"  "secret"  "$(_rand)"
+    set_env "GEMINI_API_KEY"         "Google Gemini API key [Enter to skip]"            "secret"
+    set_env "LAVALINK_PASSWORD"      "Lavalink password     [Enter to auto-generate]"  "secret"  "$(_rand)"
+    # SESSION_SECRET_KEY is always auto-generated — no need to prompt
+    set_env "SESSION_SECRET_KEY"     "" "auto" "$(_secret)"
+
+    log ".env configured"
+fi
+
+# Load env vars for use in migration step (POSTGRES_USER, POSTGRES_DB, OLLAMA_MODEL)
+set -a
+# shellcheck source=/dev/null
+source .env 2>/dev/null || true
+set +a
+
+# =============================================================================
+# Step 4: Build and start all services
+# =============================================================================
+info "Building and starting services (this may take a few minutes on first run)..."
+$DC up -d --build
+log "All services started"
+
+# =============================================================================
+# Step 5: Wait for database to be healthy
+# =============================================================================
+info "Waiting for database to become healthy..."
+TIMEOUT=120; ELAPSED=0; INTERVAL=5
+until docker inspect --format='{{.State.Health.Status}}' aetheris-db 2>/dev/null | grep -q 'healthy'; do
+    if [[ $ELAPSED -ge $TIMEOUT ]]; then
+        error "Database did not become healthy within ${TIMEOUT}s. Check: docker logs aetheris-db"
+    fi
+    sleep $INTERVAL
+    ELAPSED=$((ELAPSED + INTERVAL))
+    echo -n "."
+done
+echo ""
+log "Database is healthy"
+
+# =============================================================================
+# Step 6: Run database migrations 002–011
+# (001 is auto-applied by PostgreSQL initdb.d at first start)
+# =============================================================================
+MIGRATION_DIR="./db/migrations"
+if [[ -d "$MIGRATION_DIR" ]]; then
+    info "Applying database migrations..."
+    # Use a sorted glob so migrations apply in numeric order
+    for migration in $(ls "$MIGRATION_DIR"/*.sql 2>/dev/null | sort); do
+        filename=$(basename "$migration")
+        echo -n "  Applying ${filename} ... "
+        if $DC exec -T ironclad-db psql \
+               -U "${POSTGRES_USER:-ironclad}" \
+               -d "${POSTGRES_DB:-ironclad}" \
+               < "$migration"; then
+            echo "OK"
+        else
+            echo "FAILED"
+            error "Migration ${filename} failed. Check: docker logs aetheris-db"
+        fi
+    done
+    log "All migrations applied"
+else
+    warn "Migration directory not found at $MIGRATION_DIR — skipping."
+fi
+
+# =============================================================================
+# Step 7: Pull the default Ollama model
+# =============================================================================
+OLLAMA_MODEL="${OLLAMA_MODEL:-mistral:7b-instruct}"
+info "Pulling Ollama model: ${OLLAMA_MODEL} (may take several minutes)..."
+if $DC exec brain ollama pull "$OLLAMA_MODEL"; then
+    log "Ollama model ready: ${OLLAMA_MODEL}"
+else
+    warn "Could not pull Ollama model automatically."
+    warn "Run manually after install: $DC exec brain ollama pull ${OLLAMA_MODEL}"
+fi
+
+# =============================================================================
+# Done
+# =============================================================================
+echo ""
+echo -e "${GREEN}${BOLD}╔══════════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}${BOLD}║     ✓  Ironclad GM is running!                       ║${NC}"
+echo -e "${GREEN}${BOLD}╚══════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo "  Web Admin (White Portal):  http://localhost:8000/web/"
+echo "  Health Pulse:              http://localhost:58291/"
+echo "  Media Proxy:               http://localhost:8001/"
+echo ""
+echo "  Next steps:"
+echo "    1. Invite your Discord bot to your server"
+echo "    2. Open White Portal → Settings → Channel Map and configure your channels"
+echo "    3. Register your Ollama node(s) in White Portal → Nodes"
+echo ""
+echo "  Useful commands:"
+echo "    View logs:   $DC logs -f"
+echo "    Stop:        $DC down"
+echo "    Uninstall:   bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/RPG-Bot/main/uninstall.sh)"
+echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Ironclad GM — One-command uninstaller
+# Usage: bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/RPG-Bot/main/uninstall.sh)
+# =============================================================================
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+
+log()   { echo -e "${GREEN}[\u2713]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[!]${NC} $*"; }
+error() { echo -e "${RED}[\u2717]${NC} $*" >&2; exit 1; }
+info()  { echo -e "${CYAN}[→]${NC} $*"; }
+
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║        Ironclad GM — Uninstaller                     ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════════════════════╝${NC}"
+echo ""
+
+warn "This will permanently remove all Ironclad GM containers, Docker volumes, and local data."
+warn "This action is IRREVERSIBLE. All campaign data, character sheets, and logs will be deleted."
+echo ""
+
+read -r -p "  Type 'yes' to confirm and continue (anything else cancels): " CONFIRM </dev/tty
+if [[ "$CONFIRM" != "yes" ]]; then
+    echo "  Cancelled. No changes were made."
+    exit 0
+fi
+echo ""
+
+# =============================================================================
+# Detect docker compose
+# =============================================================================
+if docker compose version &>/dev/null 2>&1; then
+    DC="docker compose"
+elif command -v docker-compose &>/dev/null; then
+    DC="docker-compose"
+else
+    warn "Docker Compose not found — skipping container removal."
+    DC=""
+fi
+
+# =============================================================================
+# Step 1: Stop and remove containers + named volumes
+# =============================================================================
+if [[ -n "$DC" && -f "docker-compose.yml" ]]; then
+    info "Stopping containers and removing volumes..."
+    $DC down -v --remove-orphans 2>/dev/null || true
+    log "Containers and Docker volumes removed"
+elif [[ -n "$DC" ]]; then
+    warn "docker-compose.yml not found in current directory — skipping docker down."
+    warn "If containers are still running, stop them manually: docker ps | grep aetheris"
+fi
+
+# =============================================================================
+# Step 2: Remove local data directories
+# =============================================================================
+info "Removing local data directories..."
+for dir in data logs backups; do
+    if [[ -d "./$dir" ]]; then
+        rm -rf "./$dir"
+        log "  Removed ./$dir"
+    else
+        echo "    ./$dir not found — skipping"
+    fi
+done
+
+# =============================================================================
+# Step 3: Optionally remove .env (contains credentials)
+# =============================================================================
+if [[ -f ".env" ]]; then
+    echo ""
+    read -r -p "  Remove .env (contains your API keys and passwords)? (y/N): " REMOVE_ENV </dev/tty
+    if [[ "$REMOVE_ENV" =~ ^[Yy]$ ]]; then
+        rm -f .env .env.backup 2>/dev/null || true
+        log ".env removed"
+    else
+        warn ".env kept. Delete it manually when ready: rm .env"
+    fi
+fi
+
+# =============================================================================
+# Done
+# =============================================================================
+echo ""
+echo -e "${GREEN}${BOLD}╔══════════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}${BOLD}║     ✓  Ironclad GM has been uninstalled.              ║${NC}"
+echo -e "${GREEN}${BOLD}╚══════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo "  All containers, Docker volumes, and local data have been removed."
+echo ""
+echo "  To reinstall:"
+echo "    bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/RPG-Bot/main/install.sh)"
+echo ""


### PR DESCRIPTION
## Summary

Closes #27

Adds two curl-executable scripts that fully automate deployment and removal of the Ironclad GM stack.

### install.sh
- **Prerequisite checks** — fails fast if `docker`, `docker compose`/`docker-compose`, `git`, or `curl` is missing
- **Repo detection** — clones `RPG-Bot` if not already inside it; no-ops if already checked out
- **Interactive `.env` setup** — prompts for all required credentials (`DISCORD_BOT_TOKEN`, `DISCORD_APPLICATION_ID`, `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, `GEMINI_API_KEY`, `LAVALINK_PASSWORD`); auto-generates secure random values for passwords and `SESSION_SECRET_KEY`; skips entirely if `.env` already exists (idempotent)
- **curl-pipe safe** — all `read` prompts use `</dev/tty` so they work when stdin is the curl stream
- **`docker compose up -d --build`** — builds and starts all 10 services
- **DB health wait** — polls `aetheris-db` health status (120s timeout) before running migrations
- **Migrations 002–011** — piped via `docker compose exec -T ironclad-db psql ... < file.sql` (001 is auto-applied by PostgreSQL `initdb.d`)
- **Ollama model pull** — pulls `${OLLAMA_MODEL:-mistral:7b-instruct}` from inside the `brain` container
- **Access summary** — prints URLs for White Portal (`:8000`), Health Pulse (`:58291`), Media Proxy (`:8001`)

### uninstall.sh
- Requires explicit `yes` confirmation (default: cancel)
- `docker compose down -v --remove-orphans` — removes all containers and named Docker volumes
- Removes `./data`, `./logs`, `./backups` local directories
- Separate prompt before deleting `.env` (user may want to preserve credentials)

## Usage

```bash
# Install
bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/RPG-Bot/main/install.sh)

# Uninstall
bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/RPG-Bot/main/uninstall.sh)
```

## Test Plan

- [ ] Run install from a clean directory (triggers clone path)
- [ ] Run install from inside an existing checkout (skips clone)
- [ ] Verify `.env` already present → setup skipped with warning
- [ ] Confirm all 10 containers reach `running` state after install
- [ ] Confirm migrations 002–011 apply without error (`docker logs aetheris-db`)
- [ ] Confirm Web Portal accessible at `http://localhost:8000/web/`
- [ ] Run uninstall → type `yes` → confirm all `aetheris-*` containers and volumes gone (`docker ps -a`, `docker volume ls`)
- [ ] Run uninstall → type anything other than `yes` → confirm no changes made

https://claude.ai/code/session_01WSgz5XqpzKhGPjdbWo9b1w