### PR TITLE
feat(ui): Native Interactive UI Translation Layer — Discord Component Mapping (Issue #16)

### DIFF
--- a/docs/issue-16-solution.md
+++ b/docs/issue-16-solution.md
@@ -1,0 +1,148 @@
+# Issue #16 — Native Interactive UI Translation Layer (Discord Component Mapping)
+
+## Summary
+
+Implements stateless `UIComponentBuilder` that translates character state and
+mechanical resolution output into Discord interactive components (buttons and
+select menus). Players can execute RPG actions with a single click rather than
+typing raw text commands.
+
+## Architecture
+
+```
+OllamaResolutionPayload
+        │
+        ▼
+UIComponentBuilder.build_from_action_context()
+        │
+        ├─► build_combat_components()     → UIComponentSet (attack/defend/spell rows)
+        ├─► build_exploration_components() → UIComponentSet (examine/search/interact rows)
+        └─► build_inventory_page()        → UIComponentSet (ephemeral paginated menu)
+        │
+        ▼
+NarrativeResponsePayload.ui_components: UIComponentSet | None
+        │
+        ▼
+Discord bot → attaches Action Rows to narrative embed message
+        │
+        ▼  (player clicks)
+Discord interaction callback → UIComponentBuilder.decode_interaction()
+        │
+        ▼
+ComponentInteraction → re-enter pipeline as new IntentPayload
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `orchestrator/schemas/payloads.py` | Added `ButtonStyle`, `DiscordButton`, `SelectOption`, `DiscordSelectMenu`, `ActionRow`, `UIComponentSet`, `ComponentInteraction`; added `ui_components` field to `NarrativeResponsePayload` |
+| `orchestrator/services/ui_component_builder.py` | New — `UIComponentBuilder` service |
+| `orchestrator/services/__init__.py` | Added `UIComponentBuilder` export |
+| `orchestrator/tests/test_ui_component_builder.py` | New — 34 pytest tests |
+
+## Custom ID Encoding
+
+Discord limits `custom_id` to 100 characters. All component IDs use the
+compact pipe-separated format from TDR §3:
+
+```
+action:cast|spell_id:44|target:goblin_2
+```
+
+When the encoded string would exceed 100 chars, `encode_action_id()` falls back
+to a SHA-1 digest of the params while preserving the action key:
+
+```
+action:attack|h:a1b2c3d4e5f60708
+```
+
+Decoded via `decode_action_id()` → `{'action': 'attack', 'h': 'a1b2c3...'}`
+
+## Wiring into narration.py
+
+```python
+from orchestrator.services.ui_component_builder import UIComponentBuilder
+
+_ui_builder = UIComponentBuilder()
+
+# Inside narration.py after mechanical resolution and state commit:
+payload.ui_components = _ui_builder.build_from_action_context(
+    action_type=resolution.action_type,
+    character_stats=character.stats,
+    inventory=inventory_snapshot,
+    available_spells=character.stats.get("known_spells", []),
+    interactive_objects=scene_objects,   # from scene context, optional
+)
+```
+
+## Wiring into Discord bot
+
+### Attaching components to messages
+
+```python
+from orchestrator.schemas.payloads import NarrativeResponsePayload
+
+async def deliver_narrative(payload: NarrativeResponsePayload, interaction):
+    components = []
+    if payload.ui_components:
+        for row in payload.ui_components.action_rows:
+            components.append(build_discord_action_row(row))  # map to discord.py View
+    await interaction.followup.send(payload.narrative, components=components)
+```
+
+### Handling component interactions
+
+```python
+from orchestrator.services.ui_component_builder import UIComponentBuilder
+from orchestrator.schemas.payloads import IntentPayload, CommandType
+
+@bot.event
+async def on_interaction(interaction: discord.Interaction):
+    if interaction.type != discord.InteractionType.component:
+        return
+    comp_interaction = UIComponentBuilder.decode_interaction(interaction.data_raw)
+    # Convert to pipeline intent
+    intent = IntentPayload(
+        player_id=comp_interaction.player_id,
+        guild_id=comp_interaction.guild_id,
+        channel_id=comp_interaction.channel_id,
+        session_token=comp_interaction.session_token,
+        raw_input=_format_component_action(comp_interaction),
+        command_type=CommandType.SLASH_COMMAND,
+    )
+    await dispatch_to_pipeline(intent)
+```
+
+### Inventory (ephemeral)
+
+When `ui_components.ephemeral is True`, the Discord bot sends the components
+via `interaction.response.send_message(..., ephemeral=True)` so only the
+acting player sees the inventory. This prevents chat clutter and avoids
+exposing another player's inventory state.
+
+### Race-condition protection
+
+Before executing a `use_item` action from a component callback, the Discord
+bot must acquire a Redis lock on the player's inventory:
+
+```python
+lock_key = f"ironclad:lock:inventory:{player_id}"
+async with redis.lock(lock_key, timeout=5):
+    await dispatch_use_item(item_id, player_id)
+```
+
+This prevents duplicate item consumption if a player clicks the same button
+multiple times before the first response arrives.
+
+## TDR Compliance
+
+| Requirement | Implementation |
+|-------------|----------------|
+| Contextual State Fetch (§2.B.1) | `build_from_action_context()` receives inventory + spell list |
+| Component Generation (§2.B.2) | Attack buttons, utility row, spell select menu |
+| Custom ID Serialization (§3) | `action:cast\|spell_id:44\|target:goblin_2` ≤ 100 chars |
+| Callback Interception (§2.B.4) | `decode_interaction()` maps raw Discord body → `ComponentInteraction` |
+| Ephemeral Fog of War (Option 1) | `UIComponentSet.ephemeral = True` for inventory pages |
+| Paginated Inventories (Option 3) | `build_inventory_page()` with cursor prev/next navigation |
+| Security mutex (§3) | Redis lock pattern documented in wiring guide above |

--- a/orchestrator/schemas/payloads.py
+++ b/orchestrator/schemas/payloads.py
@@ -495,6 +495,85 @@ class ChannelDirective(BaseModel):
     reason:      str = Field(default="", description="Short explanation for audit logs")
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 5 – Discord Interactive Component Schemas (Issue #16)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ButtonStyle(str, Enum):
+    """Discord button visual styles."""
+    PRIMARY   = "primary"    # blurple
+    SECONDARY = "secondary"  # grey
+    SUCCESS   = "success"    # green
+    DANGER    = "danger"     # red
+
+
+class DiscordButton(BaseModel):
+    """A single Discord button component (placed inside an ActionRow)."""
+    label:     str        = Field(..., max_length=80)
+    custom_id: str        = Field(..., max_length=100,
+                                  description="Compact encoded action string: 'action:value|key:val'")
+    style:     ButtonStyle = ButtonStyle.SECONDARY
+    disabled:  bool        = False
+    emoji:     str | None  = Field(default=None, description="Unicode emoji or Discord emoji string")
+
+
+class SelectOption(BaseModel):
+    """A single option inside a DiscordSelectMenu."""
+    label:       str        = Field(..., max_length=100)
+    value:       str        = Field(..., max_length=100,
+                                    description="Compact encoded action string passed back on selection")
+    description: str        = Field(default="", max_length=100)
+    emoji:       str | None = None
+
+
+class DiscordSelectMenu(BaseModel):
+    """A Discord string-select menu component (placed alone inside an ActionRow)."""
+    custom_id:   str               = Field(..., max_length=100)
+    placeholder: str               = Field(default="Choose an action…", max_length=150)
+    options:     list[SelectOption] = Field(default_factory=list,
+                                            description="Up to 25 options per menu")
+    min_values:  int               = Field(default=1, ge=1, le=25)
+    max_values:  int               = Field(default=1, ge=1, le=25)
+
+
+class ActionRow(BaseModel):
+    """
+    One Discord Action Row: either up to 5 buttons, or exactly 1 select menu.
+    The Discord bot is responsible for enforcing the per-row component limit.
+    """
+    components: list[DiscordButton | DiscordSelectMenu] = Field(default_factory=list)
+
+
+class UIComponentSet(BaseModel):
+    """Up to 5 Action Rows attached to a single Discord message."""
+    action_rows: list[ActionRow] = Field(default_factory=list,
+                                         description="Maximum 5 rows per message")
+    ephemeral:   bool            = Field(
+        default=False,
+        description="If True the Discord bot sends these components as an ephemeral "
+                    "message visible only to the acting player (used for inventory).",
+    )
+
+
+class ComponentInteraction(BaseModel):
+    """
+    Decoded payload from a Discord component interaction callback.
+    Constructed by UIComponentBuilder.decode_interaction() and fed back into
+    the pipeline as a new IntentPayload with command_type=SLASH_COMMAND.
+    """
+    interaction_id: str
+    player_id:      str
+    guild_id:       str
+    channel_id:     str
+    message_id:     str
+    custom_id:      str
+    action:         str                     = Field(..., description="Decoded 'action' key from custom_id")
+    params:         dict[str, str]          = Field(default_factory=dict,
+                                                    description="All other decoded key→value pairs")
+    session_token:  str                     = Field(default="",
+                                                    description="Injected by bot from Redis session lookup")
+
+
 class NarrativeResponsePayload(BaseModel):
     """
     Phase 4 output – the final payload sent to Discord.
@@ -510,14 +589,14 @@ class NarrativeResponsePayload(BaseModel):
     embed_title:   str  = Field(default="", description="Short Discord embed title")
     multimedia:    list[MultimediaCue] = Field(default_factory=list)
 
-    # ── Task 4: Paranoia Whisper (Private Perception) ─────────────────────
+    # ── Task 4: Paranoia Whisper (Private Perception) ────────────────────
     whisper: str | None = Field(
         default=None,
         description="Secret GM insight DMed to the player — what their skeptical eye notices "
                     "that no one else in the scene would catch. 2-3 sentences.",
     )
 
-    # ── Task 4: Ghost Sheet / Ephemeral Thread ────────────────────────────
+    # ── Task 4: Ghost Sheet / Ephemeral Thread ──────────────────────
     thread_event:   ThreadEvent | None = Field(
         default=None,
         description="If set, the bot manages a combat/encounter thread on this message.",
@@ -532,7 +611,7 @@ class NarrativeResponsePayload(BaseModel):
                     "inventory changes, rulebook citations. Never shown in main channel.",
     )
 
-    # ── Task 4: Voice Channel Puppeteering ────────────────────────────────
+    # ── Task 4: Voice Channel Puppeteering ────────────────────────
     ambient_audio_key: str | None = Field(
         default=None,
         description="Key for the ambient audio file to loop in the voice channel "
@@ -544,14 +623,22 @@ class NarrativeResponsePayload(BaseModel):
                     "each with its Ollama node's unique voice profile.",
     )
 
-    # ── Task 4: Channel Manipulation ─────────────────────────────────────
+    # ── Task 4: Channel Manipulation ─────────────────────────────
     channel_directive: ChannelDirective | None = Field(
         default=None,
         description="If set, the bot moves the player's Discord channel access — "
                     "into the dungeon, prison, hospital, or back to main.",
     )
 
-    # ── Driftnet: World-bound broadcast channel ───────────────────────────
+    # ── Task 5: Interactive Discord Components (Issue #16) ────────────────
+    ui_components: UIComponentSet | None = Field(
+        default=None,
+        description="Clickable buttons and select menus generated from character state. "
+                    "Populated by UIComponentBuilder after mechanical resolution; "
+                    "None when no interactive choices are appropriate for this turn.",
+    )
+
+    # ── Driftnet: World-bound broadcast channel ──────────────────────
     driftnet_channel_id: str = Field(
         default="",
         description=(
@@ -561,7 +648,7 @@ class NarrativeResponsePayload(BaseModel):
         ),
     )
 
-    # ── Multimedia: Music, SFX, Images, Handouts ─────────────────────────
+    # ── Multimedia: Music, SFX, Images, Handouts ────────────────────
     sfx_cues: list[SFXCue] = Field(
         default_factory=list,
         description="Ordered list of one-shot SFX to play after the narrative lands.",
@@ -673,7 +760,7 @@ class PipelineResult(BaseModel):
 # Async Session Feature Schemas
 # ─────────────────────────────────────────────────────────────────────────────
 
-# ── Chronicle Recap ───────────────────────────────────────────────────────────
+# ── Chronicle Recap ──────────────────────────────────────────────────
 
 class RecapRequest(BaseModel):
     """
@@ -700,7 +787,7 @@ class RecapResponse(BaseModel):
     generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
-# ── Campfire Mode ─────────────────────────────────────────────────────────────
+# ── Campfire Mode ───────────────────────────────────────────────────
 
 class PresenceUpdate(BaseModel):
     """Posted by the Discord bot whenever a player's online status changes."""
@@ -724,7 +811,7 @@ class CampfireStatus(BaseModel):
     checked_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
-# ── Async Downtime Tasks ──────────────────────────────────────────────────────
+# ── Async Downtime Tasks ────────────────────────────────────────────
 
 class DowntimeSubmitRequest(BaseModel):
     """

--- a/orchestrator/services/__init__.py
+++ b/orchestrator/services/__init__.py
@@ -28,6 +28,7 @@ from .elevenlabs_client import ElevenLabsClient
 from .handout_service import HandoutService
 from .faction_service import FactionService
 from .openai_compat_client import OpenAICompatClient
+from .ui_component_builder import UIComponentBuilder
 
 __all__ = [
     "DatabaseService",
@@ -60,4 +61,5 @@ __all__ = [
     "HandoutService",
     "FactionService",
     "OpenAICompatClient",
+    "UIComponentBuilder",
 ]

--- a/orchestrator/services/ui_component_builder.py
+++ b/orchestrator/services/ui_component_builder.py
@@ -1,0 +1,367 @@
+"""
+UIComponentBuilder — translates character state into Discord interactive components.
+
+Issue #16 TDR: Native Interactive UI Translation Layer (Discord Component Mapping)
+https://github.com/Crashcart/RPG-Bot/issues/16
+
+Design rules (per TDR §3):
+- Custom IDs are ≤100 chars in the format ``action:value|key1:val1|key2:val2``.
+- Inventory menus are ephemeral (visible only to the acting player).
+- Race-condition protection: the Discord bot is responsible for a Redis
+  mutex on the player's inventory before executing any ``use_item`` action.
+- This class is stateless; it never performs DB or Redis calls directly.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from orchestrator.schemas.payloads import (
+    ActionRow,
+    ButtonStyle,
+    ComponentInteraction,
+    DiscordButton,
+    DiscordSelectMenu,
+    SelectOption,
+    UIComponentSet,
+)
+
+_MAX_OPTIONS_PER_MENU = 24   # Discord hard limit is 25; we keep 1 slot for safety
+_CUSTOM_ID_MAX_LEN    = 100  # Discord hard limit
+
+
+class UIComponentBuilder:
+    """
+    Builds Discord Action Rows from character/inventory/scene data.
+
+    Usage (in GMDirector or narration.py after mechanical resolution)::
+
+        builder = UIComponentBuilder()
+        payload.ui_components = builder.build_from_action_context(
+            action_type=resolution.action_type,
+            character_stats=character.stats,
+            inventory=inventory_snapshot,
+        )
+    """
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Custom ID encoding / decoding
+    # ──────────────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def encode_action_id(action: str, **params: str) -> str:
+        """
+        Encode an action and its parameters into a ≤100-char custom_id string.
+
+        Format: ``action:value|key1:val1|key2:val2``
+
+        When the full string would exceed 100 chars (Discord limit), the params
+        are collapsed to a 16-char SHA-1 digest so the action key is preserved.
+        """
+        parts = [f"action:{action}"]
+        for k, v in params.items():
+            parts.append(f"{k}:{v}")
+        raw = "|".join(parts)
+        if len(raw) <= _CUSTOM_ID_MAX_LEN:
+            return raw
+        digest = hashlib.sha1(raw.encode()).hexdigest()[:16]
+        return f"action:{action}|h:{digest}"
+
+    @staticmethod
+    def decode_action_id(custom_id: str) -> dict[str, str]:
+        """
+        Parse ``action:cast|spell_id:44|target:goblin_2``
+        →  ``{'action': 'cast', 'spell_id': '44', 'target': 'goblin_2'}``.
+        """
+        result: dict[str, str] = {}
+        for segment in custom_id.split("|"):
+            if ":" not in segment:
+                continue
+            key, _, val = segment.partition(":")
+            result[key.strip()] = val.strip()
+        return result
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Combat components
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def build_combat_components(
+        self,
+        character_stats: dict[str, Any],
+        equipped_weapons: list[dict[str, Any]],
+        available_spells: list[dict[str, Any]],
+    ) -> UIComponentSet:
+        """
+        Build action rows for a combat turn.
+
+        Row 0 — Attack buttons (one per equipped weapon, max 5).
+        Row 1 — Defend / Flee / Use Item utility buttons.
+        Row 2 — Spell select menu (up to 24 options; only added when spells exist).
+        """
+        rows: list[ActionRow] = []
+
+        # Row 0: attack buttons (fallback to "Unarmed Strike" when nothing equipped)
+        weapons = equipped_weapons if equipped_weapons else [
+            {"name": "Unarmed Strike", "item_id": "unarmed"}
+        ]
+        attack_buttons = [
+            DiscordButton(
+                label=f"⚔ {w.get('name', 'Attack')[:20]}",
+                custom_id=self.encode_action_id(
+                    "attack", weapon_id=str(w.get("item_id", "unarmed"))
+                ),
+                style=ButtonStyle.DANGER,
+            )
+            for w in weapons[:5]
+        ]
+        rows.append(ActionRow(components=attack_buttons))
+
+        # Row 1: utility buttons
+        rows.append(ActionRow(components=[
+            DiscordButton(
+                label="🛡 Defend",
+                custom_id=self.encode_action_id("defend"),
+                style=ButtonStyle.PRIMARY,
+            ),
+            DiscordButton(
+                label="💨 Flee",
+                custom_id=self.encode_action_id("flee"),
+                style=ButtonStyle.SECONDARY,
+            ),
+            DiscordButton(
+                label="🎒 Use Item",
+                custom_id=self.encode_action_id("inventory", page="0"),
+                style=ButtonStyle.SECONDARY,
+            ),
+        ]))
+
+        # Row 2: spell select menu (skipped when the character has no spells)
+        if available_spells:
+            options = [
+                SelectOption(
+                    label=s.get("name", "Spell")[:100],
+                    value=self.encode_action_id(
+                        "cast", spell_id=str(s.get("spell_id", "unknown"))
+                    ),
+                    description=str(s.get("description", ""))[:100],
+                    emoji=s.get("emoji"),
+                )
+                for s in available_spells[:_MAX_OPTIONS_PER_MENU]
+            ]
+            rows.append(ActionRow(components=[
+                DiscordSelectMenu(
+                    custom_id=self.encode_action_id("spell_menu"),
+                    placeholder="✨ Cast a spell…",
+                    options=options,
+                )
+            ]))
+
+        return UIComponentSet(action_rows=rows[:5])
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Exploration components
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def build_exploration_components(
+        self,
+        interactive_objects: list[dict[str, Any]] | None = None,
+    ) -> UIComponentSet:
+        """
+        Build action rows for an exploration turn.
+
+        Row 0 — Context-sensitive interaction buttons for objects in the scene
+                (only when ``interactive_objects`` is non-empty).
+        Row 1 — Universal exploration buttons: Examine / Search / Wait / Inventory.
+        """
+        rows: list[ActionRow] = []
+
+        # Row 0: per-object interaction buttons
+        if interactive_objects:
+            obj_buttons = [
+                DiscordButton(
+                    label=f"🖐 {obj.get('name', 'Object')[:20]}",
+                    custom_id=self.encode_action_id(
+                        "interact", object_id=str(obj.get("object_id", ""))
+                    ),
+                    style=ButtonStyle.PRIMARY,
+                )
+                for obj in interactive_objects[:5]
+            ]
+            rows.append(ActionRow(components=obj_buttons))
+
+        # Row 1: universal exploration buttons
+        rows.append(ActionRow(components=[
+            DiscordButton(
+                label="🔍 Examine",
+                custom_id=self.encode_action_id("examine"),
+                style=ButtonStyle.SECONDARY,
+            ),
+            DiscordButton(
+                label="🔎 Search",
+                custom_id=self.encode_action_id("search"),
+                style=ButtonStyle.SECONDARY,
+            ),
+            DiscordButton(
+                label="⏳ Wait",
+                custom_id=self.encode_action_id("wait"),
+                style=ButtonStyle.SECONDARY,
+            ),
+            DiscordButton(
+                label="🎒 Inventory",
+                custom_id=self.encode_action_id("inventory", page="0"),
+                style=ButtonStyle.SECONDARY,
+            ),
+        ]))
+
+        return UIComponentSet(action_rows=rows[:5])
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Inventory page (ephemeral, paginated)
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def build_inventory_page(
+        self,
+        inventory: list[dict[str, Any]],
+        page: int = 0,
+    ) -> UIComponentSet:
+        """
+        Build an ephemeral inventory select menu with cursor pagination.
+
+        Row 0 — Select menu of up to 24 items on the current page.
+        Row 1 — Previous / Next navigation buttons (only when multiple pages exist).
+
+        The result is always ``ephemeral=True``: the Discord bot must send it as
+        an interaction response visible only to the acting player (prevents chat
+        clutter and avoids exposing another player's inventory).
+        """
+        rows: list[ActionRow] = []
+        total_pages = max(1, (len(inventory) + _MAX_OPTIONS_PER_MENU - 1)
+                          // _MAX_OPTIONS_PER_MENU)
+        page = max(0, min(page, total_pages - 1))
+        start = page * _MAX_OPTIONS_PER_MENU
+        page_items = inventory[start : start + _MAX_OPTIONS_PER_MENU]
+
+        if page_items:
+            options = [
+                SelectOption(
+                    label=f"{item.get('name', 'Item')[:80]} ×{item.get('quantity', 1)}",
+                    value=self.encode_action_id(
+                        "use_item", item_id=str(item.get("item_id", ""))
+                    ),
+                    description=str(item.get("description", ""))[:100],
+                )
+                for item in page_items
+            ]
+            rows.append(ActionRow(components=[
+                DiscordSelectMenu(
+                    custom_id=self.encode_action_id("item_select", page=str(page)),
+                    placeholder=f"🎒 Inventory (page {page + 1}/{total_pages})",
+                    options=options,
+                )
+            ]))
+
+        # Navigation row: only added when there are multiple pages
+        if total_pages > 1:
+            nav_buttons: list[DiscordButton] = []  # type: ignore[type-arg]
+            if page > 0:
+                nav_buttons.append(DiscordButton(
+                    label="◀ Prev",
+                    custom_id=self.encode_action_id("inventory", page=str(page - 1)),
+                    style=ButtonStyle.SECONDARY,
+                ))
+            if page < total_pages - 1:
+                nav_buttons.append(DiscordButton(
+                    label="Next ▶",
+                    custom_id=self.encode_action_id("inventory", page=str(page + 1)),
+                    style=ButtonStyle.SECONDARY,
+                ))
+            if nav_buttons:
+                rows.append(ActionRow(components=nav_buttons))
+
+        return UIComponentSet(action_rows=rows, ephemeral=True)
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Main entry point
+    # ──────────────────────────────────────────────────────────────────────────
+
+    #: Action types that produce combat component rows
+    COMBAT_ACTION_TYPES: frozenset[str] = frozenset({
+        "melee_attack", "ranged_attack", "spell_cast", "grapple",
+        "combat_maneuver", "saving_throw",
+    })
+
+    #: Action types that produce exploration component rows
+    EXPLORATION_ACTION_TYPES: frozenset[str] = frozenset({
+        "examine", "search", "skill_check", "social", "stealth",
+        "interact", "perception",
+    })
+
+    def build_from_action_context(
+        self,
+        action_type: str,
+        character_stats: dict[str, Any],
+        inventory: list[dict[str, Any]] | None = None,
+        available_spells: list[dict[str, Any]] | None = None,
+        interactive_objects: list[dict[str, Any]] | None = None,
+    ) -> UIComponentSet | None:
+        """
+        Top-level factory: return the appropriate component set for the given
+        ``action_type`` (from ``OllamaResolutionPayload.action_type``).
+
+        Returns ``None`` for turns that produce no interactive choices —
+        pure narration, downtime, OOC messages, or unrecognised action types.
+        """
+        equipped = [i for i in (inventory or []) if i.get("equipped")]
+        spells   = available_spells or []
+
+        if action_type in self.COMBAT_ACTION_TYPES:
+            return self.build_combat_components(
+                character_stats=character_stats,
+                equipped_weapons=equipped,
+                available_spells=spells,
+            )
+        if action_type in self.EXPLORATION_ACTION_TYPES:
+            return self.build_exploration_components(
+                interactive_objects=interactive_objects,
+            )
+        return None
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Interaction callback decoder
+    # ──────────────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def decode_interaction(raw: dict[str, Any]) -> ComponentInteraction:
+        """
+        Decode a Discord component interaction POST body into a
+        ``ComponentInteraction``.
+
+        ``raw`` is the full JSON dict that Discord sends to the interaction
+        endpoint when a player clicks a button or selects a menu option.
+        """
+        data   = raw.get("data", {})
+        cid    = data.get("custom_id", "")
+
+        # Select menus nest the chosen value one level deeper
+        values = data.get("values", [])
+        if values:
+            cid = values[0]
+
+        params = UIComponentBuilder.decode_action_id(cid)
+        action = params.pop("action", "unknown")
+
+        # Member vs DM interaction: player_id lives in different places
+        member  = raw.get("member") or {}
+        user    = member.get("user") or raw.get("user") or {}
+        player_id = str(user.get("id", ""))
+
+        return ComponentInteraction(
+            interaction_id=str(raw.get("id", "")),
+            player_id=player_id,
+            guild_id=str(raw.get("guild_id", "")),
+            channel_id=str(raw.get("channel_id", "")),
+            message_id=str((raw.get("message") or {}).get("id", "")),
+            custom_id=cid,
+            action=action,
+            params=params,
+        )

--- a/orchestrator/tests/test_ui_component_builder.py
+++ b/orchestrator/tests/test_ui_component_builder.py
@@ -1,0 +1,425 @@
+"""
+Tests for UIComponentBuilder — Issue #16.
+
+Run with: pytest orchestrator/tests/test_ui_component_builder.py -v
+"""
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.schemas.payloads import (
+    ButtonStyle,
+    DiscordButton,
+    DiscordSelectMenu,
+    UIComponentSet,
+)
+from orchestrator.services.ui_component_builder import (
+    _CUSTOM_ID_MAX_LEN,
+    _MAX_OPTIONS_PER_MENU,
+    UIComponentBuilder,
+)
+
+
+@pytest.fixture
+def builder() -> UIComponentBuilder:
+    return UIComponentBuilder()
+
+
+@pytest.fixture
+def sample_inventory() -> list[dict]:
+    return [
+        {"item_id": f"item_{i}", "name": f"Potion {i}", "quantity": 1,
+         "description": f"A healing potion #{i}", "equipped": False}
+        for i in range(30)
+    ]
+
+
+@pytest.fixture
+def sample_weapons() -> list[dict]:
+    return [
+        {"item_id": "sword_1", "name": "Longsword", "equipped": True},
+        {"item_id": "dagger_2", "name": "Dagger", "equipped": True},
+    ]
+
+
+@pytest.fixture
+def sample_spells() -> list[dict]:
+    return [
+        {"spell_id": "fireball", "name": "Fireball", "description": "Deals fire damage"},
+        {"spell_id": "heal", "name": "Heal", "description": "Restores HP"},
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestEncodeDecodeRoundTrip
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestEncodeDecodeRoundTrip:
+    def test_simple_action_roundtrip(self, builder: UIComponentBuilder) -> None:
+        cid = builder.encode_action_id("attack", weapon_id="sword_1")
+        decoded = builder.decode_action_id(cid)
+        assert decoded["action"] == "attack"
+        assert decoded["weapon_id"] == "sword_1"
+
+    def test_multiple_params_roundtrip(self, builder: UIComponentBuilder) -> None:
+        cid = builder.encode_action_id("cast", spell_id="fireball", target="goblin_2")
+        decoded = builder.decode_action_id(cid)
+        assert decoded["action"] == "cast"
+        assert decoded["spell_id"] == "fireball"
+        assert decoded["target"] == "goblin_2"
+
+    def test_custom_id_format(self, builder: UIComponentBuilder) -> None:
+        cid = builder.encode_action_id("cast", spell_id="44", target="goblin_2")
+        assert cid == "action:cast|spell_id:44|target:goblin_2"
+
+    def test_encoded_id_within_discord_limit(self, builder: UIComponentBuilder) -> None:
+        cid = builder.encode_action_id("attack", weapon_id="a" * 50, target="b" * 50)
+        assert len(cid) <= _CUSTOM_ID_MAX_LEN
+
+    def test_long_params_fall_back_to_hash(self, builder: UIComponentBuilder) -> None:
+        long_val = "x" * 200
+        cid = builder.encode_action_id("attack", weapon_id=long_val)
+        assert len(cid) <= _CUSTOM_ID_MAX_LEN
+        decoded = builder.decode_action_id(cid)
+        assert decoded["action"] == "attack"
+        assert "h" in decoded  # hash digest present
+
+    def test_no_params(self, builder: UIComponentBuilder) -> None:
+        cid = builder.encode_action_id("defend")
+        decoded = builder.decode_action_id(cid)
+        assert decoded["action"] == "defend"
+
+    def test_decode_malformed_segment_skipped(self, builder: UIComponentBuilder) -> None:
+        decoded = builder.decode_action_id("action:flee|INVALID|key:val")
+        assert decoded["action"] == "flee"
+        assert decoded["key"] == "val"
+        assert "INVALID" not in decoded
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestCombatComponents
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCombatComponents:
+    def test_returns_ui_component_set(
+        self, builder: UIComponentBuilder, sample_weapons: list[dict]
+    ) -> None:
+        result = builder.build_combat_components(
+            character_stats={}, equipped_weapons=sample_weapons, available_spells=[]
+        )
+        assert isinstance(result, UIComponentSet)
+
+    def test_two_rows_without_spells(
+        self, builder: UIComponentBuilder, sample_weapons: list[dict]
+    ) -> None:
+        result = builder.build_combat_components(
+            character_stats={}, equipped_weapons=sample_weapons, available_spells=[]
+        )
+        assert len(result.action_rows) == 2
+
+    def test_three_rows_with_spells(
+        self,
+        builder: UIComponentBuilder,
+        sample_weapons: list[dict],
+        sample_spells: list[dict],
+    ) -> None:
+        result = builder.build_combat_components(
+            character_stats={}, equipped_weapons=sample_weapons,
+            available_spells=sample_spells
+        )
+        assert len(result.action_rows) == 3
+
+    def test_attack_buttons_use_danger_style(
+        self, builder: UIComponentBuilder, sample_weapons: list[dict]
+    ) -> None:
+        result = builder.build_combat_components(
+            character_stats={}, equipped_weapons=sample_weapons, available_spells=[]
+        )
+        attack_row = result.action_rows[0]
+        for btn in attack_row.components:
+            assert isinstance(btn, DiscordButton)
+            assert btn.style == ButtonStyle.DANGER
+
+    def test_unarmed_fallback_when_no_weapons(
+        self, builder: UIComponentBuilder
+    ) -> None:
+        result = builder.build_combat_components(
+            character_stats={}, equipped_weapons=[], available_spells=[]
+        )
+        attack_row = result.action_rows[0]
+        assert len(attack_row.components) == 1
+        btn = attack_row.components[0]
+        assert isinstance(btn, DiscordButton)
+        assert "Unarmed" in btn.label
+
+    def test_max_five_attack_buttons(
+        self, builder: UIComponentBuilder
+    ) -> None:
+        many_weapons = [{"item_id": f"w{i}", "name": f"Weapon {i}", "equipped": True}
+                        for i in range(10)]
+        result = builder.build_combat_components(
+            character_stats={}, equipped_weapons=many_weapons, available_spells=[]
+        )
+        assert len(result.action_rows[0].components) <= 5
+
+    def test_spell_row_is_select_menu(
+        self,
+        builder: UIComponentBuilder,
+        sample_weapons: list[dict],
+        sample_spells: list[dict],
+    ) -> None:
+        result = builder.build_combat_components(
+            character_stats={}, equipped_weapons=sample_weapons,
+            available_spells=sample_spells
+        )
+        spell_row = result.action_rows[2]
+        assert len(spell_row.components) == 1
+        assert isinstance(spell_row.components[0], DiscordSelectMenu)
+
+    def test_total_rows_never_exceed_five(
+        self, builder: UIComponentBuilder
+    ) -> None:
+        spells = [{"spell_id": f"s{i}", "name": f"Spell {i}"} for i in range(30)]
+        weapons = [{"item_id": f"w{i}", "name": f"Sword {i}", "equipped": True}
+                   for i in range(10)]
+        result = builder.build_combat_components(
+            character_stats={}, equipped_weapons=weapons, available_spells=spells
+        )
+        assert len(result.action_rows) <= 5
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestExplorationComponents
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestExplorationComponents:
+    def test_returns_ui_component_set(self, builder: UIComponentBuilder) -> None:
+        result = builder.build_exploration_components()
+        assert isinstance(result, UIComponentSet)
+
+    def test_one_row_without_objects(self, builder: UIComponentBuilder) -> None:
+        result = builder.build_exploration_components(interactive_objects=None)
+        assert len(result.action_rows) == 1
+
+    def test_two_rows_with_objects(self, builder: UIComponentBuilder) -> None:
+        objects = [{"object_id": "door_1", "name": "Iron Door"}]
+        result = builder.build_exploration_components(interactive_objects=objects)
+        assert len(result.action_rows) == 2
+
+    def test_universal_row_has_four_buttons(self, builder: UIComponentBuilder) -> None:
+        result = builder.build_exploration_components()
+        universal_row = result.action_rows[-1]
+        assert len(universal_row.components) == 4
+
+    def test_not_ephemeral(self, builder: UIComponentBuilder) -> None:
+        result = builder.build_exploration_components()
+        assert result.ephemeral is False
+
+    def test_max_five_object_buttons(self, builder: UIComponentBuilder) -> None:
+        objects = [{"object_id": f"obj_{i}", "name": f"Object {i}"} for i in range(10)]
+        result = builder.build_exploration_components(interactive_objects=objects)
+        assert len(result.action_rows[0].components) <= 5
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestInventoryPage
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestInventoryPage:
+    def test_always_ephemeral(
+        self, builder: UIComponentBuilder, sample_inventory: list[dict]
+    ) -> None:
+        result = builder.build_inventory_page(sample_inventory)
+        assert result.ephemeral is True
+
+    def test_single_page_no_nav_row(self, builder: UIComponentBuilder) -> None:
+        small_inv = [{"item_id": f"i{i}", "name": f"Item {i}", "quantity": 1}
+                     for i in range(5)]
+        result = builder.build_inventory_page(small_inv)
+        assert len(result.action_rows) == 1  # only select menu, no nav
+
+    def test_multi_page_has_nav_row(
+        self, builder: UIComponentBuilder, sample_inventory: list[dict]
+    ) -> None:
+        result = builder.build_inventory_page(sample_inventory, page=0)
+        assert len(result.action_rows) == 2  # select menu + nav
+
+    def test_page_clipped_to_last_valid_page(
+        self, builder: UIComponentBuilder, sample_inventory: list[dict]
+    ) -> None:
+        result = builder.build_inventory_page(sample_inventory, page=999)
+        assert len(result.action_rows) >= 1
+
+    def test_page_clipped_to_zero(
+        self, builder: UIComponentBuilder, sample_inventory: list[dict]
+    ) -> None:
+        result = builder.build_inventory_page(sample_inventory, page=-5)
+        assert len(result.action_rows) >= 1
+
+    def test_options_per_page_within_limit(
+        self, builder: UIComponentBuilder, sample_inventory: list[dict]
+    ) -> None:
+        result = builder.build_inventory_page(sample_inventory, page=0)
+        menu = result.action_rows[0].components[0]
+        assert isinstance(menu, DiscordSelectMenu)
+        assert len(menu.options) <= _MAX_OPTIONS_PER_MENU
+
+    def test_prev_button_absent_on_first_page(
+        self, builder: UIComponentBuilder, sample_inventory: list[dict]
+    ) -> None:
+        result = builder.build_inventory_page(sample_inventory, page=0)
+        nav_buttons = result.action_rows[1].components
+        labels = [btn.label for btn in nav_buttons if isinstance(btn, DiscordButton)]
+        assert not any("Prev" in lbl for lbl in labels)
+
+    def test_next_button_absent_on_last_page(
+        self, builder: UIComponentBuilder, sample_inventory: list[dict]
+    ) -> None:
+        result = builder.build_inventory_page(sample_inventory, page=1)
+        nav_buttons = result.action_rows[1].components
+        labels = [btn.label for btn in nav_buttons if isinstance(btn, DiscordButton)]
+        assert not any("Next" in lbl for lbl in labels)
+
+    def test_empty_inventory_returns_empty_rows(
+        self, builder: UIComponentBuilder
+    ) -> None:
+        result = builder.build_inventory_page([], page=0)
+        assert result.action_rows == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestBuildFromActionContext
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestBuildFromActionContext:
+    def test_melee_attack_returns_combat(
+        self, builder: UIComponentBuilder, sample_weapons: list[dict]
+    ) -> None:
+        result = builder.build_from_action_context(
+            action_type="melee_attack",
+            character_stats={},
+            inventory=sample_weapons,
+        )
+        assert result is not None
+        assert not result.ephemeral
+
+    def test_spell_cast_returns_combat(
+        self,
+        builder: UIComponentBuilder,
+        sample_weapons: list[dict],
+        sample_spells: list[dict],
+    ) -> None:
+        result = builder.build_from_action_context(
+            action_type="spell_cast",
+            character_stats={},
+            inventory=sample_weapons,
+            available_spells=sample_spells,
+        )
+        assert result is not None
+
+    def test_examine_returns_exploration(self, builder: UIComponentBuilder) -> None:
+        result = builder.build_from_action_context(
+            action_type="examine", character_stats={}
+        )
+        assert result is not None
+        assert not result.ephemeral
+
+    def test_skill_check_returns_exploration(self, builder: UIComponentBuilder) -> None:
+        result = builder.build_from_action_context(
+            action_type="skill_check", character_stats={}
+        )
+        assert result is not None
+
+    def test_unknown_action_returns_none(self, builder: UIComponentBuilder) -> None:
+        result = builder.build_from_action_context(
+            action_type="ooc_message", character_stats={}
+        )
+        assert result is None
+
+    def test_only_equipped_items_used_as_weapons(
+        self, builder: UIComponentBuilder
+    ) -> None:
+        inventory = [
+            {"item_id": "sword", "name": "Sword", "equipped": True},
+            {"item_id": "potion", "name": "Potion", "equipped": False},
+        ]
+        result = builder.build_from_action_context(
+            action_type="melee_attack", character_stats={}, inventory=inventory
+        )
+        assert result is not None
+        attack_labels = [
+            btn.label
+            for btn in result.action_rows[0].components
+            if isinstance(btn, DiscordButton)
+        ]
+        assert any("Sword" in lbl for lbl in attack_labels)
+        assert not any("Potion" in lbl for lbl in attack_labels)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestDecodeInteraction
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDecodeInteraction:
+    def _make_button_raw(self, custom_id: str, player_id: str = "123") -> dict:
+        return {
+            "id": "inter_001",
+            "guild_id": "guild_999",
+            "channel_id": "chan_888",
+            "member": {"user": {"id": player_id}},
+            "message": {"id": "msg_777"},
+            "data": {"custom_id": custom_id, "component_type": 2},
+        }
+
+    def _make_select_raw(self, value: str, player_id: str = "123") -> dict:
+        return {
+            "id": "inter_002",
+            "guild_id": "guild_999",
+            "channel_id": "chan_888",
+            "member": {"user": {"id": player_id}},
+            "message": {"id": "msg_777"},
+            "data": {
+                "custom_id": "item_select",
+                "component_type": 3,
+                "values": [value],
+            },
+        }
+
+    def test_button_interaction_decoded(self) -> None:
+        raw = self._make_button_raw("action:attack|weapon_id:sword_1")
+        result = UIComponentBuilder.decode_interaction(raw)
+        assert result.action == "attack"
+        assert result.params["weapon_id"] == "sword_1"
+        assert result.player_id == "123"
+
+    def test_select_menu_value_overrides_custom_id(self) -> None:
+        raw = self._make_select_raw("action:cast|spell_id:fireball")
+        result = UIComponentBuilder.decode_interaction(raw)
+        assert result.action == "cast"
+        assert result.params["spell_id"] == "fireball"
+
+    def test_interaction_fields_populated(self) -> None:
+        raw = self._make_button_raw("action:defend", player_id="456")
+        result = UIComponentBuilder.decode_interaction(raw)
+        assert result.interaction_id == "inter_001"
+        assert result.guild_id == "guild_999"
+        assert result.channel_id == "chan_888"
+        assert result.message_id == "msg_777"
+        assert result.player_id == "456"
+
+    def test_dm_interaction_no_member(self) -> None:
+        raw = {
+            "id": "inter_dm",
+            "guild_id": "",
+            "channel_id": "dm_chan",
+            "user": {"id": "789"},
+            "message": {"id": "dm_msg"},
+            "data": {"custom_id": "action:flee"},
+        }
+        result = UIComponentBuilder.decode_interaction(raw)
+        assert result.player_id == "789"
+        assert result.action == "flee"
+
+    def test_empty_body_returns_unknown_action(self) -> None:
+        result = UIComponentBuilder.decode_interaction({})
+        assert result.action == "unknown"


### PR DESCRIPTION
## Summary

- Adds `UIComponentBuilder` service that translates `OllamaResolutionPayload.action_type` + character state into Discord Action Row components
- Adds 7 new Pydantic schemas to `payloads.py`: `ButtonStyle`, `DiscordButton`, `SelectOption`, `DiscordSelectMenu`, `ActionRow`, `UIComponentSet`, `ComponentInteraction`
- Wires `ui_components: UIComponentSet | None` field into `NarrativeResponsePayload`
- 34 pytest unit tests covering encode/decode round-trip, combat layout, exploration layout, paginated inventory, action context routing, and interaction callback decoding

## Changes

| File | Change |
|------|--------|
| `orchestrator/schemas/payloads.py` | Added Discord component schemas + `ui_components` field on `NarrativeResponsePayload` |
| `orchestrator/services/ui_component_builder.py` | New — stateless `UIComponentBuilder` service |
| `orchestrator/services/__init__.py` | Added `UIComponentBuilder` export |
| `orchestrator/tests/__init__.py` | New (empty) |
| `orchestrator/tests/test_ui_component_builder.py` | New — 34 pytest tests |
| `docs/issue-16-solution.md` | New — architecture diagram, wiring guide, TDR compliance table |

## TDR Compliance (Issue #16)

| Requirement | Status |
|-------------|--------|
| Contextual State Fetch (§2.B.1) | ✅ `build_from_action_context()` receives inventory + spell list |
| Component Generation (§2.B.2) | ✅ Attack buttons, utility row, spell select menu |
| Custom ID Serialization (§3) | ✅ `action:cast\|spell_id:44\|target:goblin_2` ≤ 100 chars; SHA-1 fallback |
| Callback Interception (§2.B.4) | ✅ `decode_interaction()` maps raw Discord body → `ComponentInteraction` |
| Ephemeral Fog of War (Option 1) | ✅ `UIComponentSet.ephemeral = True` for inventory pages |
| Paginated Inventories (Option 3) | ✅ `build_inventory_page()` with prev/next nav |
| Security mutex (§3) | ✅ Redis lock pattern documented in `docs/issue-16-solution.md` |

## Test plan

- [ ] `pytest orchestrator/tests/test_ui_component_builder.py -v` — all 34 tests pass
- [ ] `from orchestrator.schemas.payloads import UIComponentSet, ComponentInteraction` — imports cleanly
- [ ] `NarrativeResponsePayload(prompt_id='x', intent_id='y', narrative='z')` — `ui_components` defaults to `None`
- [ ] Verify `encode_action_id` output stays ≤ 100 chars under long-param conditions
- [ ] Wire `build_from_action_context()` call into `narration.py` after merge

## Wiring (post-merge)

```python
# narration.py — after mechanical resolution and state commit:
from orchestrator.services.ui_component_builder import UIComponentBuilder
_ui_builder = UIComponentBuilder()
payload.ui_components = _ui_builder.build_from_action_context(
    action_type=resolution.action_type,
    character_stats=character.stats,
    inventory=inventory_snapshot,
    available_spells=character.stats.get("known_spells", []),
    interactive_objects=scene_objects,
)
```

See `docs/issue-16-solution.md` for the full Discord bot wiring guide including component attachment, interaction callback handling, and Redis inventory lock.

https://claude.ai/code/session_01D8YWan8xaJs2zidWPn8GBc

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8YWan8xaJs2zidWPn8GBc)_