### PR TITLE
test(critical): 80 unit tests for RealityWall and WorldRegistry

### DIFF
--- a/.claude/scheduled-execution.log
+++ b/.claude/scheduled-execution.log
@@ -1,0 +1,25 @@
+[2026-07-25T11:11:42Z] [CONFIG] Loaded .github/docker-optimization.md (general Docker optimization guide; no automation rules found)
+[2026-07-25T11:11:42Z] [INFO] No copilot-instructions.md found — operating with default rules from CLAUDE.md
+[2026-07-25T11:11:42Z] [INFO] Initialized for crashcart/rpg-bot
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #25 enhancement PRed(#61) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #24 enhancement PRed(#60) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #23 enhancement PRed(#63) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #22 enhancement PRed(#62) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #21 enhancement PRed(unlinked) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #19 enhancement PRed(unlinked) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #18 enhancement PRed(#64) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #17 enhancement PRed(unlinked) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #16 enhancement PRed(unlinked) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #15 enhancement PRed(#56) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #14 enhancement PRed(#51) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #13 enhancement PRed(#50) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #12 enhancement PRed(unlinked) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #11 enhancement PRed(#67) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #10 enhancement PRed(#58) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #9 enhancement PRed(#57) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #8 enhancement PRed(unlinked) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #7 enhancement PRed(#53) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY] Issue #6 enhancement,help_wanted PRed(#52) no-new-work
+[2026-07-25T11:15:02Z] [DISCOVERY COMPLETE] 19 issues evaluated; all have open PRs; 0 unimplemented; proceeding with highest-value gap work
+[2026-07-25T11:15:02Z] [DECISION] All issues PRed. Zero test coverage on main. PR#68 covers ParadoxEngine. Selecting RealityWall+WorldRegistry (two CLAUDE.md Critical Logic Modules) as test targets — no open PR covers them.
+[2026-07-25T11:15:02Z] [PHASE 1/4] Branch: claude/feat/reality-wall-world-registry-tests created off main

--- a/docs/reality-wall-world-registry-tests.md
+++ b/docs/reality-wall-world-registry-tests.md
@@ -1,0 +1,44 @@
+# Test Suite: RealityWall & WorldRegistry
+
+Two CLAUDE.md Critical Logic Modules now have full unit-test coverage.
+
+## Files added
+
+| File | Tests | What it validates |
+|------|-------|-------------------|
+| `orchestrator/tests/conftest.py` | — | Stubs env vars + missing optional deps so test imports work without a live stack |
+| `orchestrator/tests/test_reality_wall.py` | 35 | Full coverage of `RealityWall` |
+| `orchestrator/tests/test_world_registry.py` | 45 | Full coverage of `WorldRegistry` + `WorldSchema` |
+
+**Total: 80 tests — all passing.**
+
+## RealityWall coverage (35 tests)
+
+| Class | Tests |
+|-------|-------|
+| `TestInit` | Directory tree creation, SQLite file creation, WAL mode active, idempotent init |
+| `TestWorldRegistration` | Register creates DB entry + handouts/ + echo_vault/ dirs, list, idempotent, metadata, empty list |
+| `TestCampaignWorldBinding` | Set/get roundtrip, unknown campaign → None, auto-register on set, rebinding, multi-campaign isolation |
+| `TestDriftnetChannel` | Set/get roundtrip, unset → None, unknown world → None, update, auto-create world on set |
+| `TestParadoxLevel` | Default=1, roundtrip, clamp <1, clamp >10, boundary 1, boundary 10, update, campaign isolation |
+| `TestPathIsolation` | Correct handout/vault paths, traversal `../../` rejected, absolute escape rejected, nested subdir allowed |
+
+## WorldRegistry coverage (45 tests)
+
+| Class | Tests |
+|-------|-------|
+| `TestScan` | Empty dirs, fonts-only, templates-only, merged, dedup, cache population, sorted result |
+| `TestMetadataPriority` | world.json loads, identity.json loads, override, empty value does not clobber, no-JSON minimal schema, malformed JSON graceful fallback (both tiers), system defaults to folder name, full world.json |
+| `TestCacheMethods` | Empty before scan, sorted list after scan, get_schema hit/miss, reload re-reads disk |
+| `TestManifest` | Creates dir + world.json, returns schema, existing → False, calls RealityWall, idempotent, minimal fields, adds to cache |
+| `TestCampaignHelpers` | switch calls RealityWall, manifests new world, None when no world, returns schema |
+| `TestSlugify` | 7 parametrized cases |
+| `TestWorldSchemaProperties` | embed_color parses hex, default white, gm_tone_block both/tone-only/empty, driftnet default |
+
+## Running
+
+```bash
+pip install pytest pydantic-settings
+pytest orchestrator/tests/test_reality_wall.py orchestrator/tests/test_world_registry.py -v
+# Expected: 80 passed
+```

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -1,0 +1,65 @@
+"""
+Shared pytest configuration for orchestrator tests.
+
+Stubs required environment variables so Pydantic Settings can import
+the app modules without a live stack (no .env, no running containers).
+
+Also installs lightweight mock modules for optional heavy dependencies
+(asyncpg, redis, aiohttp, etc.) that are not available in the test
+environment but are imported at module-load time by the services package.
+"""
+
+import os
+import sys
+import types
+
+# ---------------------------------------------------------------------------
+# Env var stubs (required by pydantic-settings in config.py)
+# ---------------------------------------------------------------------------
+os.environ.setdefault("POSTGRES_PASSWORD", "test_pg_pass")
+os.environ.setdefault("REDIS_PASSWORD", "test_redis_pass")
+os.environ.setdefault("GEMINI_API_KEY", "test_gemini_key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test_discord_token")
+os.environ.setdefault("DISCORD_APPLICATION_ID", "123456789012345678")
+os.environ.setdefault("LAVALINK_PASSWORD", "test_lavalink_pass")
+os.environ.setdefault("SESSION_SECRET_KEY", "test_session_secret_key_32_chars!!")
+
+
+def _stub_module(name: str, **attrs):
+    """Register a no-op module under `name` if it isn't already importable."""
+    if name in sys.modules:
+        return
+    mod = types.ModuleType(name)
+    for attr, value in attrs.items():
+        setattr(mod, attr, value)
+    sys.modules[name] = mod
+    # Also register sub-packages so dotted imports don't fail
+    parts = name.split(".")
+    for i in range(1, len(parts)):
+        parent = ".".join(parts[:i])
+        if parent not in sys.modules:
+            sys.modules[parent] = types.ModuleType(parent)
+
+
+# Heavy optional dependencies not installed in the CI/test environment
+_stub_module("asyncpg")
+_stub_module("asyncpg.pool")
+_stub_module("redis")
+_stub_module("redis.asyncio")
+_stub_module("redis.asyncio.client")
+_stub_module("aiohttp")
+_stub_module("google.generativeai", GenerativeModel=object)
+_stub_module("google")
+_stub_module("google.generativeai")
+_stub_module("anthropic")
+_stub_module("openai")
+_stub_module("chromadb")
+_stub_module("chromadb.utils")
+_stub_module("chromadb.utils.embedding_functions")
+_stub_module("wavelink")
+_stub_module("nats")
+_stub_module("nats.aio")
+_stub_module("nats.aio.client")
+_stub_module("discord")
+_stub_module("discord.ext")
+_stub_module("discord.ext.commands")

--- a/orchestrator/tests/test_reality_wall.py
+++ b/orchestrator/tests/test_reality_wall.py
@@ -1,0 +1,310 @@
+"""
+Unit tests for RealityWall — SQLite-backed world-state registry.
+
+Tests cover:
+- Directory and schema initialisation
+- World registration and listing
+- Campaign ↔ world binding (set/get, auto-register)
+- Driftnet channel binding
+- Paradox level CRUD (default, clamp, roundtrip)
+- Path isolation (resolve_handout_path / resolve_vault_path, traversal guard)
+- SQLite WAL mode is active after init
+"""
+
+import asyncio
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load reality_wall directly from its source file to avoid triggering the
+# heavy services/__init__.py (which requires asyncpg, httpx, chromadb, etc.)
+# ---------------------------------------------------------------------------
+ROOT = Path(__file__).parent.parent.parent
+_MODULE_PATH = ROOT / "orchestrator" / "services" / "reality_wall.py"
+_spec = importlib.util.spec_from_file_location("orchestrator.services.reality_wall", _MODULE_PATH)
+_mod  = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+RealityWall = _mod.RealityWall
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_wall(tmp_path: Path) -> RealityWall:
+    """Return an initialised RealityWall pointing at a temp directory."""
+    return RealityWall(data_dir=str(tmp_path), vault_dir=str(tmp_path / "vault"))
+
+
+async def _init(rw: RealityWall) -> RealityWall:
+    await rw.init()
+    return rw
+
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+class TestInit:
+    def test_creates_directory_tree(self, tmp_path):
+        rw = _make_wall(tmp_path)
+        asyncio.run(rw.init())
+        for asset_type in ("fonts", "templates", "handouts", "echo_vault", "vault"):
+            assert (tmp_path / asset_type).is_dir(), f"{asset_type}/ not created"
+
+    def test_creates_sqlite_database(self, tmp_path):
+        rw = _make_wall(tmp_path)
+        asyncio.run(rw.init())
+        assert (tmp_path / "vault" / "scribe_core.db").exists()
+
+    def test_wal_mode_active(self, tmp_path):
+        rw = _make_wall(tmp_path)
+        asyncio.run(rw.init())
+        db_path = tmp_path / "vault" / "scribe_core.db"
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute("PRAGMA journal_mode").fetchone()
+        assert row[0] == "wal"
+
+    def test_init_idempotent(self, tmp_path):
+        """Calling init() twice must not raise."""
+        rw = _make_wall(tmp_path)
+        asyncio.run(rw.init())
+        asyncio.run(rw.init())
+        assert (tmp_path / "vault" / "scribe_core.db").exists()
+
+
+# ---------------------------------------------------------------------------
+# World Registration
+# ---------------------------------------------------------------------------
+
+class TestWorldRegistration:
+    def setup_method(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp()
+        self.tmp = Path(self._tmpdir)
+        self.rw = _make_wall(self.tmp)
+        asyncio.run(self.rw.init())
+
+    def test_register_creates_world_entry(self):
+        asyncio.run(self.rw.register_world("mothership"))
+        worlds = asyncio.run(self.rw.list_worlds())
+        assert "mothership" in worlds
+
+    def test_register_creates_handouts_dir(self):
+        asyncio.run(self.rw.register_world("shadowrun"))
+        assert (self.tmp / "handouts" / "shadowrun").is_dir()
+
+    def test_register_creates_echo_vault_dir(self):
+        asyncio.run(self.rw.register_world("shadowrun"))
+        assert (self.tmp / "echo_vault" / "shadowrun").is_dir()
+
+    def test_register_multiple_worlds(self):
+        asyncio.run(self.rw.register_world("mothership"))
+        asyncio.run(self.rw.register_world("shadowrun"))
+        asyncio.run(self.rw.register_world("pirate_borg"))
+        worlds = asyncio.run(self.rw.list_worlds())
+        assert set(worlds) == {"mothership", "shadowrun", "pirate_borg"}
+
+    def test_register_idempotent(self):
+        """Re-registering the same world must not raise or duplicate."""
+        asyncio.run(self.rw.register_world("mothership"))
+        asyncio.run(self.rw.register_world("mothership"))
+        worlds = asyncio.run(self.rw.list_worlds())
+        assert worlds.count("mothership") == 1
+
+    def test_register_with_metadata(self):
+        asyncio.run(self.rw.register_world("vtm", {"edition": "v5"}))
+        worlds = asyncio.run(self.rw.list_worlds())
+        assert "vtm" in worlds
+
+    def test_list_worlds_empty_initially(self):
+        worlds = asyncio.run(self.rw.list_worlds())
+        assert worlds == []
+
+
+# ---------------------------------------------------------------------------
+# Campaign ↔ World Binding
+# ---------------------------------------------------------------------------
+
+class TestCampaignWorldBinding:
+    def setup_method(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp()
+        self.tmp = Path(self._tmpdir)
+        self.rw = _make_wall(self.tmp)
+        asyncio.run(self.rw.init())
+
+    def test_set_and_get_current_world(self):
+        asyncio.run(self.rw.register_world("mothership"))
+        asyncio.run(self.rw.set_current_world("campaign-001", "mothership"))
+        result = asyncio.run(self.rw.get_current_world("campaign-001"))
+        assert result == "mothership"
+
+    def test_get_current_world_unknown_campaign_returns_none(self):
+        result = asyncio.run(self.rw.get_current_world("nonexistent-campaign"))
+        assert result is None
+
+    def test_set_current_world_auto_registers_world(self):
+        """set_current_world should auto-register a world that doesn't exist yet."""
+        asyncio.run(self.rw.set_current_world("campaign-002", "new_world"))
+        worlds = asyncio.run(self.rw.list_worlds())
+        assert "new_world" in worlds
+
+    def test_campaign_world_can_be_changed(self):
+        asyncio.run(self.rw.register_world("mothership"))
+        asyncio.run(self.rw.register_world("shadowrun"))
+        asyncio.run(self.rw.set_current_world("campaign-003", "mothership"))
+        asyncio.run(self.rw.set_current_world("campaign-003", "shadowrun"))
+        result = asyncio.run(self.rw.get_current_world("campaign-003"))
+        assert result == "shadowrun"
+
+    def test_multiple_campaigns_independent(self):
+        asyncio.run(self.rw.register_world("mothership"))
+        asyncio.run(self.rw.register_world("vtm"))
+        asyncio.run(self.rw.set_current_world("campaign-a", "mothership"))
+        asyncio.run(self.rw.set_current_world("campaign-b", "vtm"))
+        assert asyncio.run(self.rw.get_current_world("campaign-a")) == "mothership"
+        assert asyncio.run(self.rw.get_current_world("campaign-b")) == "vtm"
+
+
+# ---------------------------------------------------------------------------
+# Driftnet Channel Binding
+# ---------------------------------------------------------------------------
+
+class TestDriftnetChannel:
+    def setup_method(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp()
+        self.tmp = Path(self._tmpdir)
+        self.rw = _make_wall(self.tmp)
+        asyncio.run(self.rw.init())
+
+    def test_set_and_get_driftnet_channel(self):
+        asyncio.run(self.rw.register_world("mothership"))
+        asyncio.run(self.rw.set_driftnet_channel("mothership", "123456789012345678"))
+        result = asyncio.run(self.rw.get_driftnet_channel("mothership"))
+        assert result == "123456789012345678"
+
+    def test_get_driftnet_channel_unset_returns_none(self):
+        asyncio.run(self.rw.register_world("shadowrun"))
+        result = asyncio.run(self.rw.get_driftnet_channel("shadowrun"))
+        assert result is None
+
+    def test_get_driftnet_channel_unknown_world_returns_none(self):
+        result = asyncio.run(self.rw.get_driftnet_channel("does_not_exist"))
+        assert result is None
+
+    def test_driftnet_channel_can_be_updated(self):
+        asyncio.run(self.rw.register_world("vtm"))
+        asyncio.run(self.rw.set_driftnet_channel("vtm", "111"))
+        asyncio.run(self.rw.set_driftnet_channel("vtm", "999"))
+        result = asyncio.run(self.rw.get_driftnet_channel("vtm"))
+        assert result == "999"
+
+    def test_driftnet_auto_creates_world_on_set(self):
+        """set_driftnet_channel upserts world_state so it must succeed even for a new world."""
+        asyncio.run(self.rw.set_driftnet_channel("pirate_borg", "42"))
+        result = asyncio.run(self.rw.get_driftnet_channel("pirate_borg"))
+        assert result == "42"
+
+
+# ---------------------------------------------------------------------------
+# Paradox Level
+# ---------------------------------------------------------------------------
+
+class TestParadoxLevel:
+    def setup_method(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp()
+        self.tmp = Path(self._tmpdir)
+        self.rw = _make_wall(self.tmp)
+        asyncio.run(self.rw.init())
+
+    def test_default_paradox_level_is_one(self):
+        level = asyncio.run(self.rw.get_paradox_level("campaign-xyz"))
+        assert level == 1
+
+    def test_set_and_get_paradox_level(self):
+        asyncio.run(self.rw.set_paradox_level("campaign-001", 7))
+        level = asyncio.run(self.rw.get_paradox_level("campaign-001"))
+        assert level == 7
+
+    def test_paradox_level_clamps_below_one(self):
+        asyncio.run(self.rw.set_paradox_level("campaign-002", 0))
+        assert asyncio.run(self.rw.get_paradox_level("campaign-002")) == 1
+
+    def test_paradox_level_clamps_above_ten(self):
+        asyncio.run(self.rw.set_paradox_level("campaign-003", 11))
+        assert asyncio.run(self.rw.get_paradox_level("campaign-003")) == 10
+
+    def test_paradox_level_accepts_boundary_one(self):
+        asyncio.run(self.rw.set_paradox_level("campaign-004", 1))
+        assert asyncio.run(self.rw.get_paradox_level("campaign-004")) == 1
+
+    def test_paradox_level_accepts_boundary_ten(self):
+        asyncio.run(self.rw.set_paradox_level("campaign-005", 10))
+        assert asyncio.run(self.rw.get_paradox_level("campaign-005")) == 10
+
+    def test_paradox_level_can_be_updated(self):
+        asyncio.run(self.rw.set_paradox_level("campaign-006", 3))
+        asyncio.run(self.rw.set_paradox_level("campaign-006", 8))
+        assert asyncio.run(self.rw.get_paradox_level("campaign-006")) == 8
+
+    def test_paradox_levels_are_campaign_isolated(self):
+        asyncio.run(self.rw.set_paradox_level("campaign-a", 2))
+        asyncio.run(self.rw.set_paradox_level("campaign-b", 9))
+        assert asyncio.run(self.rw.get_paradox_level("campaign-a")) == 2
+        assert asyncio.run(self.rw.get_paradox_level("campaign-b")) == 9
+
+
+# ---------------------------------------------------------------------------
+# Path Isolation (Traversal Guard)
+# ---------------------------------------------------------------------------
+
+class TestPathIsolation:
+    def setup_method(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp()
+        self.tmp = Path(self._tmpdir)
+        self.rw = _make_wall(self.tmp)
+        asyncio.run(self.rw.init())
+
+    def test_resolve_handout_path_returns_correct_path(self):
+        asyncio.run(self.rw.register_world("mothership"))
+        path = self.rw.resolve_handout_path("mothership", "map.png")
+        expected_root = (self.tmp / "handouts" / "mothership").resolve()
+        assert str(path).startswith(str(expected_root))
+        assert path.name == "map.png"
+
+    def test_resolve_vault_path_returns_correct_path(self):
+        asyncio.run(self.rw.register_world("mothership"))
+        path = self.rw.resolve_vault_path("mothership", "ambient.mp3")
+        expected_root = (self.tmp / "echo_vault" / "mothership").resolve()
+        assert str(path).startswith(str(expected_root))
+        assert path.name == "ambient.mp3"
+
+    def test_resolve_handout_path_rejects_traversal(self):
+        asyncio.run(self.rw.register_world("mothership"))
+        with pytest.raises(ValueError, match="traversal"):
+            self.rw.resolve_handout_path("mothership", "../../secret.txt")
+
+    def test_resolve_vault_path_rejects_traversal(self):
+        asyncio.run(self.rw.register_world("mothership"))
+        with pytest.raises(ValueError, match="traversal"):
+            self.rw.resolve_vault_path("mothership", "../../../etc/passwd")
+
+    def test_resolve_handout_path_rejects_absolute_escape(self):
+        asyncio.run(self.rw.register_world("mothership"))
+        with pytest.raises(ValueError, match="traversal"):
+            self.rw.resolve_handout_path("mothership", "/etc/passwd")
+
+    def test_resolve_handout_path_allows_nested_subdir(self):
+        """Paths that stay inside the world dir are valid."""
+        asyncio.run(self.rw.register_world("mothership"))
+        path = self.rw.resolve_handout_path("mothership", "maps/level1.png")
+        expected_root = (self.tmp / "handouts" / "mothership").resolve()
+        assert str(path).startswith(str(expected_root))

--- a/orchestrator/tests/test_world_registry.py
+++ b/orchestrator/tests/test_world_registry.py
@@ -1,0 +1,409 @@
+"""
+Unit tests for WorldRegistry — Dynamic Genre Orchestration.
+
+Tests cover:
+- scan() with empty dirs, fonts-only, templates-only, and merged discovery
+- Metadata priority: identity.json overrides world.json (TDR §3)
+- Malformed JSON is handled gracefully (fallback to minimal schema)
+- list_worlds() returns sorted display names
+- get_schema() cache hit and miss
+- reload() forces a re-read from disk
+- manifest() creates new world on disk + returns (schema, True)
+- manifest() on existing world returns (schema, False)
+- switch_campaign_world() delegates to RealityWall.set_current_world
+- get_campaign_schema() retrieves the world schema for an active campaign
+- _slugify() helper converts folder names correctly
+- gm_tone_block property returns correct injection block
+- WorldSchema.embed_color converts hex to int
+"""
+
+import asyncio
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load world_registry and world_schema directly from source files to avoid
+# triggering the heavy services/__init__.py.
+# ---------------------------------------------------------------------------
+ROOT = Path(__file__).parent.parent.parent
+
+def _load(dotted_name: str, rel_path: str):
+    spec = importlib.util.spec_from_file_location(dotted_name, ROOT / rel_path)
+    mod  = importlib.util.module_from_spec(spec)
+    sys.modules[dotted_name] = mod  # register so cross-module imports resolve
+    spec.loader.exec_module(mod)
+    return mod
+
+_world_schema_mod   = _load("orchestrator.schemas.world_schema",  "orchestrator/schemas/world_schema.py")
+_world_registry_mod = _load("orchestrator.services.world_registry", "orchestrator/services/world_registry.py")
+
+WorldSchema   = _world_schema_mod.WorldSchema
+WorldRegistry = _world_registry_mod.WorldRegistry
+_slugify      = _world_registry_mod._slugify
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_registry(tmp_path: Path) -> tuple[WorldRegistry, MagicMock]:
+    """Return (WorldRegistry, mock_reality_wall) wired to tmp_path."""
+    rw = MagicMock()
+    rw.register_world = AsyncMock()
+    rw.set_current_world = AsyncMock()
+    rw.get_current_world = AsyncMock(return_value=None)
+    registry = WorldRegistry(data_dir=str(tmp_path), reality_wall=rw)
+    return registry, rw
+
+
+def _write_world_json(fonts_dir: Path, world_name: str, data: dict) -> None:
+    world_dir = fonts_dir / world_name
+    world_dir.mkdir(parents=True, exist_ok=True)
+    (world_dir / "world.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def _write_identity_json(templates_dir: Path, world_name: str, data: dict) -> None:
+    world_dir = templates_dir / world_name
+    world_dir.mkdir(parents=True, exist_ok=True)
+    (world_dir / "identity.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# scan()
+# ---------------------------------------------------------------------------
+
+class TestScan:
+    def test_scan_empty_dirs_returns_empty_list(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        result = asyncio.run(registry.scan())
+        assert result == []
+
+    def test_scan_discovers_world_from_fonts(self, tmp_path):
+        _write_world_json(tmp_path / "fonts", "mothership", {"display_name": "Mothership"})
+        registry, _ = _make_registry(tmp_path)
+        result = asyncio.run(registry.scan())
+        assert "mothership" in result
+
+    def test_scan_discovers_world_from_templates(self, tmp_path):
+        _write_identity_json(tmp_path / "templates", "shadowrun", {"display_name": "Shadowrun"})
+        registry, _ = _make_registry(tmp_path)
+        result = asyncio.run(registry.scan())
+        assert "shadowrun" in result
+
+    def test_scan_merges_both_dirs(self, tmp_path):
+        _write_world_json(tmp_path / "fonts", "mothership", {"display_name": "Mothership"})
+        _write_identity_json(tmp_path / "templates", "vtm", {"display_name": "VtM"})
+        registry, _ = _make_registry(tmp_path)
+        result = asyncio.run(registry.scan())
+        assert set(result) == {"mothership", "vtm"}
+
+    def test_scan_deduplicates_world_in_both_tiers(self, tmp_path):
+        _write_world_json(tmp_path / "fonts", "mothership", {"display_name": "Mothership"})
+        _write_identity_json(tmp_path / "templates", "mothership", {"display_name": "Mothership"})
+        registry, _ = _make_registry(tmp_path)
+        result = asyncio.run(registry.scan())
+        assert result.count("mothership") == 1
+
+    def test_scan_populates_cache(self, tmp_path):
+        _write_world_json(tmp_path / "fonts", "mothership", {"display_name": "Mothership"})
+        registry, _ = _make_registry(tmp_path)
+        asyncio.run(registry.scan())
+        assert registry.get_schema("mothership") is not None
+
+    def test_scan_returns_sorted_list(self, tmp_path):
+        for name in ("zardoz", "mothership", "amber"):
+            _write_world_json(tmp_path / "fonts", name, {"display_name": name.title()})
+        registry, _ = _make_registry(tmp_path)
+        result = asyncio.run(registry.scan())
+        assert result == sorted(result)
+
+
+# ---------------------------------------------------------------------------
+# Metadata priority (identity.json overrides world.json)
+# ---------------------------------------------------------------------------
+
+class TestMetadataPriority:
+    def test_loads_display_name_from_world_json(self, tmp_path):
+        _write_world_json(tmp_path / "fonts", "mothership", {"display_name": "Mothership"})
+        registry, _ = _make_registry(tmp_path)
+        schema = registry._load_from_disk("mothership")
+        assert schema.display_name == "Mothership"
+
+    def test_loads_narrative_tone_from_identity_json(self, tmp_path):
+        _write_identity_json(
+            tmp_path / "templates", "mothership",
+            {"display_name": "Mothership", "narrative_tone": "grimdark sci-fi horror"},
+        )
+        registry, _ = _make_registry(tmp_path)
+        schema = registry._load_from_disk("mothership")
+        assert schema.narrative_tone == "grimdark sci-fi horror"
+
+    def test_identity_json_overrides_world_json_tone(self, tmp_path):
+        _write_world_json(
+            tmp_path / "fonts", "mothership",
+            {"display_name": "Mothership", "narrative_tone": "generic sci-fi"},
+        )
+        _write_identity_json(
+            tmp_path / "templates", "mothership",
+            {"display_name": "Mothership Override", "narrative_tone": "grimdark sci-fi horror"},
+        )
+        registry, _ = _make_registry(tmp_path)
+        schema = registry._load_from_disk("mothership")
+        assert schema.narrative_tone == "grimdark sci-fi horror"
+        assert schema.display_name == "Mothership Override"
+
+    def test_identity_json_does_not_override_with_empty_values(self, tmp_path):
+        """Empty string in identity.json must NOT overwrite a non-empty world.json value."""
+        _write_world_json(
+            tmp_path / "fonts", "mothership",
+            {"display_name": "Mothership", "narrative_tone": "cosmic horror"},
+        )
+        _write_identity_json(
+            tmp_path / "templates", "mothership",
+            {"display_name": "Mothership", "narrative_tone": ""},
+        )
+        registry, _ = _make_registry(tmp_path)
+        schema = registry._load_from_disk("mothership")
+        assert schema.narrative_tone == "cosmic horror"
+
+    def test_minimal_schema_returned_when_no_json(self, tmp_path):
+        (tmp_path / "fonts" / "new_world").mkdir(parents=True, exist_ok=True)
+        registry, _ = _make_registry(tmp_path)
+        schema = registry._load_from_disk("new_world")
+        assert isinstance(schema, WorldSchema)
+        assert schema.system == "new_world"
+
+    def test_malformed_world_json_falls_back_to_minimal(self, tmp_path):
+        world_dir = tmp_path / "fonts" / "broken"
+        world_dir.mkdir(parents=True, exist_ok=True)
+        (world_dir / "world.json").write_text("{not valid json}", encoding="utf-8")
+        registry, _ = _make_registry(tmp_path)
+        schema = registry._load_from_disk("broken")
+        assert isinstance(schema, WorldSchema)
+
+    def test_malformed_identity_json_falls_back_gracefully(self, tmp_path):
+        _write_world_json(
+            tmp_path / "fonts", "mothership",
+            {"display_name": "Mothership"},
+        )
+        id_dir = tmp_path / "templates" / "mothership"
+        id_dir.mkdir(parents=True, exist_ok=True)
+        (id_dir / "identity.json").write_text("{bad json", encoding="utf-8")
+        registry, _ = _make_registry(tmp_path)
+        schema = registry._load_from_disk("mothership")
+        assert schema.display_name == "Mothership"
+
+    def test_system_defaults_to_folder_name_when_blank(self, tmp_path):
+        _write_world_json(
+            tmp_path / "fonts", "pirate_borg",
+            {"display_name": "Pirate Borg", "system": ""},
+        )
+        registry, _ = _make_registry(tmp_path)
+        schema = registry._load_from_disk("pirate_borg")
+        assert schema.system == "pirate_borg"
+
+    def test_loads_full_world_json(self, tmp_path):
+        data = {
+            "display_name": "Pirate Borg",
+            "primary_color": "#FFD700",
+            "narrative_tone": "grimdark pirate chaos",
+            "system": "pirate_borg",
+            "dice_notation": "d6",
+            "tags": ["pirate", "grimdark", "horror"],
+        }
+        _write_world_json(tmp_path / "fonts", "pirate_borg", data)
+        registry, _ = _make_registry(tmp_path)
+        schema = registry._load_from_disk("pirate_borg")
+        assert schema.primary_color == "#FFD700"
+        assert schema.dice_notation == "d6"
+        assert "pirate" in schema.tags
+
+
+# ---------------------------------------------------------------------------
+# list_worlds / get_schema / reload
+# ---------------------------------------------------------------------------
+
+class TestCacheMethods:
+    def test_list_worlds_empty_before_scan(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        assert registry.list_worlds() == []
+
+    def test_list_worlds_after_scan_sorted_by_display_name(self, tmp_path):
+        worlds = {
+            "zzz_world": "Zzz World",
+            "aaa_world": "Aaa World",
+            "mmm_world": "Mmm World",
+        }
+        for folder, display in worlds.items():
+            _write_world_json(tmp_path / "fonts", folder, {"display_name": display})
+        registry, _ = _make_registry(tmp_path)
+        asyncio.run(registry.scan())
+        names = [s.display_name for s in registry.list_worlds()]
+        assert names == sorted(names, key=str.lower)
+
+    def test_get_schema_returns_cached_schema(self, tmp_path):
+        _write_world_json(tmp_path / "fonts", "mothership", {"display_name": "Mothership"})
+        registry, _ = _make_registry(tmp_path)
+        asyncio.run(registry.scan())
+        schema = registry.get_schema("mothership")
+        assert schema is not None
+        assert schema.display_name == "Mothership"
+
+    def test_get_schema_returns_none_for_unknown_world(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        assert registry.get_schema("does_not_exist") is None
+
+    def test_reload_refreshes_cache(self, tmp_path):
+        _write_world_json(tmp_path / "fonts", "mothership", {"display_name": "Old Name"})
+        registry, _ = _make_registry(tmp_path)
+        asyncio.run(registry.scan())
+        assert registry.get_schema("mothership").display_name == "Old Name"
+        # Update the JSON on disk
+        _write_world_json(tmp_path / "fonts", "mothership", {"display_name": "New Name"})
+        schema = registry.reload("mothership")
+        assert schema.display_name == "New Name"
+        assert registry.get_schema("mothership").display_name == "New Name"
+
+
+# ---------------------------------------------------------------------------
+# manifest()
+# ---------------------------------------------------------------------------
+
+class TestManifest:
+    def test_manifest_creates_new_world_dir_and_world_json(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        schema, manifested = asyncio.run(registry.manifest("pirate_borg"))
+        assert manifested is True
+        assert (tmp_path / "fonts" / "pirate_borg" / "world.json").exists()
+
+    def test_manifest_returns_schema(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        schema, manifested = asyncio.run(registry.manifest("pirate_borg"))
+        assert isinstance(schema, WorldSchema)
+
+    def test_manifest_existing_world_returns_false(self, tmp_path):
+        _write_world_json(tmp_path / "fonts", "mothership", {"display_name": "Mothership"})
+        registry, _ = _make_registry(tmp_path)
+        asyncio.run(registry.scan())
+        _, manifested = asyncio.run(registry.manifest("mothership"))
+        assert manifested is False
+
+    def test_manifest_new_world_registers_with_reality_wall(self, tmp_path):
+        registry, rw = _make_registry(tmp_path)
+        asyncio.run(registry.manifest("new_world"))
+        rw.register_world.assert_called()
+
+    def test_manifest_twice_is_idempotent(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        _, first = asyncio.run(registry.manifest("pirate_borg"))
+        _, second = asyncio.run(registry.manifest("pirate_borg"))
+        assert first is True
+        assert second is False
+
+    def test_manifest_world_json_contains_minimal_fields(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        asyncio.run(registry.manifest("test_world"))
+        raw = json.loads((tmp_path / "fonts" / "test_world" / "world.json").read_text())
+        assert "display_name" in raw
+        assert "system" in raw
+
+    def test_manifest_adds_world_to_cache(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        asyncio.run(registry.manifest("new_game"))
+        assert registry.get_schema("new_game") is not None
+
+
+# ---------------------------------------------------------------------------
+# switch_campaign_world / get_campaign_schema
+# ---------------------------------------------------------------------------
+
+class TestCampaignHelpers:
+    def test_switch_campaign_world_calls_reality_wall(self, tmp_path):
+        _write_world_json(tmp_path / "fonts", "mothership", {"display_name": "Mothership"})
+        registry, rw = _make_registry(tmp_path)
+        asyncio.run(registry.scan())
+        asyncio.run(registry.switch_campaign_world("campaign-001", "mothership"))
+        rw.set_current_world.assert_called_once_with("campaign-001", "mothership")
+
+    def test_switch_campaign_world_manifests_if_needed(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        _, manifested = asyncio.run(registry.switch_campaign_world("campaign-002", "new_world"))
+        assert manifested is True
+
+    def test_get_campaign_schema_returns_none_when_no_world_set(self, tmp_path):
+        registry, rw = _make_registry(tmp_path)
+        rw.get_current_world = AsyncMock(return_value=None)
+        result = asyncio.run(registry.get_campaign_schema("campaign-000"))
+        assert result is None
+
+    def test_get_campaign_schema_returns_schema(self, tmp_path):
+        _write_world_json(tmp_path / "fonts", "mothership", {"display_name": "Mothership"})
+        registry, rw = _make_registry(tmp_path)
+        asyncio.run(registry.scan())
+        rw.get_current_world = AsyncMock(return_value="mothership")
+        schema = asyncio.run(registry.get_campaign_schema("campaign-001"))
+        assert schema is not None
+        assert schema.display_name == "Mothership"
+
+
+# ---------------------------------------------------------------------------
+# _slugify helper
+# ---------------------------------------------------------------------------
+
+class TestSlugify:
+    @pytest.mark.parametrize("input_name,expected", [
+        ("mothership",               "Mothership"),
+        ("pirate_borg",              "Pirate Borg"),
+        ("vampire_the_masquerade",   "Vampire The Masquerade"),
+        # capitalize() lowercases the rest of each word, so "6e" → "6e" not "6E"
+        ("shadowrun_6e",             "Shadowrun 6e"),
+        ("single",                   "Single"),
+        ("with-dashes",              "With Dashes"),
+        ("UPPER_CASE",               "Upper Case"),
+    ])
+    def test_slugify(self, input_name, expected):
+        assert _slugify(input_name) == expected
+
+
+# ---------------------------------------------------------------------------
+# WorldSchema properties
+# ---------------------------------------------------------------------------
+
+class TestWorldSchemaProperties:
+    def test_embed_color_parses_hex(self):
+        schema = WorldSchema(display_name="Test", primary_color="#FF4500")
+        assert schema.embed_color == 0xFF4500
+
+    def test_embed_color_default_is_white(self):
+        # primary_color defaults to "#FFFFFF" when not supplied
+        schema = WorldSchema(display_name="Test")
+        assert schema.embed_color == 0xFFFFFF
+
+    def test_gm_tone_block_both_fields(self):
+        schema = WorldSchema(
+            display_name="Test",
+            narrative_tone="grimdark",
+            description="A dark world.",
+        )
+        block = schema.gm_tone_block
+        assert "NARRATIVE TONE: grimdark" in block
+        assert "WORLD CONTEXT: A dark world." in block
+
+    def test_gm_tone_block_tone_only(self):
+        schema = WorldSchema(display_name="Test", narrative_tone="space opera")
+        block = schema.gm_tone_block
+        assert "NARRATIVE TONE: space opera" in block
+        assert "WORLD CONTEXT" not in block
+
+    def test_gm_tone_block_empty_when_no_tone_or_description(self):
+        schema = WorldSchema(display_name="Test")
+        assert schema.gm_tone_block == ""
+
+    def test_driftnet_channel_id_defaults_empty(self):
+        schema = WorldSchema(display_name="Test")
+        assert schema.driftnet_channel_id == ""


### PR DESCRIPTION
## Summary

`RealityWall` and `WorldRegistry` are two of the six **Critical Logic Modules** listed in CLAUDE.md. The main branch had zero test coverage for either. This PR establishes the `orchestrator/tests/` package and covers both modules with 80 unit tests.

## What changed

| File | Purpose |
|------|---------|
| `orchestrator/tests/__init__.py` | Creates the tests package |
| `orchestrator/tests/conftest.py` | Stubs env vars + optional heavy deps (asyncpg, httpx, chromadb, etc.) so tests run without a live stack |
| `orchestrator/tests/test_reality_wall.py` | **35 tests** for `RealityWall` |
| `orchestrator/tests/test_world_registry.py` | **45 tests** for `WorldRegistry` + `WorldSchema` |
| `docs/reality-wall-world-registry-tests.md` | Coverage summary and run instructions |

## RealityWall — 35 tests

| Class | Coverage |
|-------|---------|
| `TestInit` | Directory tree, SQLite file, WAL mode active, idempotent |
| `TestWorldRegistration` | DB entry + handouts/ + echo_vault/ created, listing, idempotent, metadata |
| `TestCampaignWorldBinding` | set/get roundtrip, unknown → None, auto-register on bind, rebind, multi-campaign isolation |
| `TestDriftnetChannel` | set/get roundtrip, unset → None, unknown world → None, update, auto-create world |
| `TestParadoxLevel` | default=1, roundtrip, clamp <1, clamp >10, boundaries 1 and 10, update, campaign isolation |
| `TestPathIsolation` | Correct paths, `../../` traversal rejected, absolute escape rejected, nested subdir allowed |

## WorldRegistry — 45 tests

| Class | Coverage |
|-------|---------|
| `TestScan` | Empty dirs, fonts-only, templates-only, merged, dedup, cache population, sorted result |
| `TestMetadataPriority` | TDR §3 identity.json overrides world.json; empty value does not clobber; malformed JSON graceful fallback; system defaults to folder name |
| `TestCacheMethods` | list sorted, get hit/miss, reload re-reads disk |
| `TestManifest` | New world created + world.json written; existing world → `manifested=False`; registers with RealityWall; idempotent; adds to cache |
| `TestCampaignHelpers` | switch_campaign_world delegates to RealityWall; get_campaign_schema returns None / correct schema |
| `TestSlugify` | 7 parametrized cases |
| `TestWorldSchemaProperties` | embed_color hex parse, default white, gm_tone_block both/tone-only/empty, driftnet default |

## Test plan

```bash
pip install pytest pydantic-settings
pytest orchestrator/tests/test_reality_wall.py orchestrator/tests/test_world_registry.py -v
# Expected: 80 passed
```

## Context

All 19 open issues already have open PRs awaiting merge. PR #68 (opened yesterday) covers `ParadoxEngine` tests. This PR covers the remaining two untested Critical Logic Modules. No existing PR overlaps with this work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MB2SnfLRcxBoAk4nQLpCvq)_