### PR TITLE
feat(prophetic): GET /api/prophetic/stats — cache hit-rate & queue metrics

### DIFF
--- a/.claude/scheduled-execution.log
+++ b/.claude/scheduled-execution.log
@@ -1,0 +1,27 @@
+[2026-08-01T11:06:58Z] [CONFIG] Loaded .github/docker-optimization.md (Docker image optimization reference guide - no issue workflow rules, tier definitions, or PR templates found)
+[2026-08-01T11:06:58Z] [INFO] No .github/copilot-instructions.md found - using default autonomous agent rules from task prompt
+[2026-08-01T11:06:58Z] [INFO] Initialized for crashcart/rpg-bot
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #6 feat/docker-preflight | has PR #52 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #7 feat/object-tracker | has PR #53 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #8 feat/nats-bus | has PR #65 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #9 feat/campaign-vault | has PR #57 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #10 feat/nats-integration | has PR #58 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #11 feat/stealth-mechanics | has PR #67 (refreshed 2026-07-23) | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #12 feat/immersion-middleware | has PR #49 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #13 feat/abes | has PR #50 (refreshed 2026-07-29) | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #14 feat/speculative-branches | has PR #51 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #15 feat/tts-pipeline | has PR #56 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #16 feat/discord-ui-components | has PR #54 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #17 feat/rulebook-ingestion | has PR #55 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #18 feat/audiocraft-soundscaping | has PR #64 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #19 feat/whisper-protocol | has PR #48 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #20 CLOSED as duplicate | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #21 feat/cargo-hauling | has PR #59 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #22 feat/edge-cluster | has PR #62 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #23 feat/lavalink-integration | has PR #63 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #24 feat/market-maker | has PR #60 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY] Issue #25 feat/module-exporter | has PR #61 | SKIP
+[2026-08-01T11:12:29Z] [DISCOVERY COMPLETE] 19 open issues, all with existing PRs. Selected backlog item from .github/TODO.md: PropheticBuffer cache hit rate endpoint
+[2026-08-01T11:12:29Z] [PHASE 1/4] Branch: claude/feat/prophetic-buffer-stats. Based on main (373f3c8).
+[2026-08-01T11:12:29Z] [PHASE 2/4] No docs file needed (endpoint is additive, no migration, self-documenting)
+[2026-08-01T11:12:29Z] [PHASE 3/4] Modified orchestrator/services/prophetic_buffer.py and orchestrator/main.py

--- a/.claude/scheduled-execution.log
+++ b/.claude/scheduled-execution.log
@@ -25,3 +25,7 @@
 [2026-08-01T11:12:29Z] [PHASE 1/4] Branch: claude/feat/prophetic-buffer-stats. Based on main (373f3c8).
 [2026-08-01T11:12:29Z] [PHASE 2/4] No docs file needed (endpoint is additive, no migration, self-documenting)
 [2026-08-01T11:12:29Z] [PHASE 3/4] Modified orchestrator/services/prophetic_buffer.py and orchestrator/main.py
+[2026-08-01T11:13:30Z] [PUSH] Code pushed to claude/feat/prophetic-buffer-stats
+[2026-08-01T11:13:30Z] [PULL_REQUEST] PR #74 created: https://github.com/Crashcart/RPG-Bot/pull/74
+[2026-08-01T11:13:30Z] [PHASE 4/4] PR #74 open. No CI configured on main branch. No review comments. Mergeable state: clean.
+[2026-08-01T11:13:30Z] [ESCALATION] PR #74 awaiting human merge — no CI to drive green.

--- a/.github/TODO.md
+++ b/.github/TODO.md
@@ -1,0 +1,55 @@
+# Ironclad GM — Task Tracker
+
+One agent, one in-progress task at a time. Mark completed immediately after finishing.
+
+Statuses: `[x]` completed · `[-]` in-progress · `[ ]` not-started
+
+---
+
+## Active Session: `claude/api-payload-schemas-0jkYr`
+
+### Multimedia Expansion
+- [x] Create `db/migrations/012_multimedia.sql` — handouts, factions, npc_portraits, music_feedback
+- [x] Extend `orchestrator/schemas/payloads.py` — SFXCue, MusicCue, new NarrativeResponsePayload fields
+- [x] Add new env vars to `orchestrator/config.py` — elevenlabs, comfyui, stability_ai, groq, openrouter, together, openai, sillytavern
+- [x] Create `orchestrator/services/openai_compat_client.py` — Groq/OpenRouter/Together/SillyTavern
+- [x] Create `orchestrator/services/elevenlabs_client.py` — SFX + TTS REST client
+- [x] Create `orchestrator/services/image_gen.py` — ComfyUI / Stability AI / DALL-E 3 backend
+- [x] Create `orchestrator/services/handout_service.py` — AI-authored in-world documents
+- [x] Create `orchestrator/services/faction_service.py` — reputation scores + AI auto-adjust
+- [x] Update `orchestrator/services/gemini_client.py` — generate_music() via Lyria 3
+- [x] Update `orchestrator/services/gm_director.py` — orchestrator context, sound/scene sub-agents, multimedia payload
+- [x] Update `orchestrator/services/node_router.py` — SillyTavern URL-busting cache, cloud adj routing
+- [x] Update `orchestrator/prompts/gm_prompts.py` — new sub-agent prompts, GM_DIRECTOR_ORCHESTRATOR_CONTEXT
+- [x] Update `orchestrator/services/sub_agent_dispatcher.py` — sound_director + scene_describer types
+- [x] Update `discord-bot/voice_manager.py` — Lyria loop, SFX, TTS provider switching, idle watchdog
+- [x] Update `discord-bot/bot.py` — on_voice_state_update, multimedia delivery, /handout /map /reputation /music commands
+- [x] Add multimedia API endpoints to `orchestrator/main.py`
+- [x] Create `db/migrations/013_inference_settings.sql` — system_settings seeds
+- [x] Add SillyTavern to `orchestrator/services/openai_compat_client.py`, `config.py`, `web_ui.py`, `settings.html`
+
+### Governance / .github
+- [x] Create `.github/` governance files (REPO_SETUP_GUIDE, copilot-instructions, REPO_CONFIG, TODO, PLANNING, BRANCH_AWARE_FILES, ci.yml, pull_request_template)
+
+### White Portal
+- [x] Create `handouts.html`, `factions.html`, `gm_advisor.html` templates
+- [x] Update `web_ui.py` — handouts/factions/gm-advisor GET+POST routes
+- [x] Update `base.html` nav — Handouts, Factions, Advisor links
+- [x] Create `compose.alpha.yml`, `compose.beta.yml`, `compose.prod.yml` tier overrides
+
+### Pending
+- [x] Add ComfyUI service to `docker-compose.yml`
+- [x] Expand `PropheticBuffer.run_idle_prefetch()` — music/portraits/scene images/recaps during idle
+- [x] Brand filtering — update sub-agent post-processor to allow PDF-sourced names
+- [x] Expose `handout_svc`, `faction_svc`, `gemini`, `world_registry` on `app.state` in `main.py` lifespan so web_ui routes can resolve them
+
+---
+
+## Backlog
+
+- [ ] `discord-bot/requirements.txt` — pin versions for all dependencies
+- [x] Add `pytest` test suite scaffold under `orchestrator/tests/`
+- [ ] Extend pipeline phase tests — integration tests against a real Postgres/Redis (testcontainers)
+- [ ] Telemetry WebSocket — add reconnect logic on client disconnect
+- [ ] Rolling Vault — add configurable window size to White Portal settings
+- [x] PropheticBuffer — expose cache hit rate via `/api/prophetic/stats` endpoint

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -1096,6 +1096,11 @@ async def api_faction_standings(campaign_id: str, player_id: str) -> list[dict]:
     return await faction_svc.get_standings(player_id, campaign_id)
 
 
+@app.get("/api/prophetic/stats", summary="PropheticBuffer cache hit-rate and queue metrics")
+async def api_prophetic_stats() -> dict:
+    return prophetic_buffer.stats()
+
+
 @app.post("/api/music/feedback", summary="Submit music feedback (approve/disapprove)")
 async def api_music_feedback(req: dict) -> dict:
     campaign_id    = req.get("campaign_id", "")

--- a/orchestrator/services/prophetic_buffer.py
+++ b/orchestrator/services/prophetic_buffer.py
@@ -83,10 +83,38 @@ class PropheticBuffer:
         self._queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=_MAX_QUEUE)
         self._task: asyncio.Task | None = None
         self._busy        = False
+        # Hit-rate counters (asyncio single-thread — no lock needed)
+        self._prefetch_count = 0
+        self._drop_count     = 0
+        self._text_hits      = 0
+        self._text_misses    = 0
+        self._audio_hits     = 0
+        self._audio_misses   = 0
 
     @property
     def is_busy(self) -> bool:
         return self._busy
+
+    def stats(self) -> dict:
+        """Return a snapshot of prefetch performance counters."""
+        total_text  = self._text_hits  + self._text_misses
+        total_audio = self._audio_hits + self._audio_misses
+        return {
+            "prefetch_count": self._prefetch_count,
+            "drop_count":     self._drop_count,
+            "queue_depth":    self._queue.qsize(),
+            "is_busy":        self._busy,
+            "text": {
+                "hits":     self._text_hits,
+                "misses":   self._text_misses,
+                "hit_rate": round(self._text_hits / total_text, 4) if total_text else 0.0,
+            },
+            "audio": {
+                "hits":     self._audio_hits,
+                "misses":   self._audio_misses,
+                "hit_rate": round(self._audio_hits / total_audio, 4) if total_audio else 0.0,
+            },
+        }
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -114,6 +142,7 @@ class PropheticBuffer:
         try:
             self._queue.put_nowait(result)
         except asyncio.QueueFull:
+            self._drop_count += 1
             logger.debug("PropheticBuffer queue full — prefetch dropped for intent %s",
                          result.intent.intent_id)
 
@@ -125,6 +154,7 @@ class PropheticBuffer:
             self._busy = True
             try:
                 await self._prefetch(result)
+                self._prefetch_count += 1
             except Exception as exc:
                 logger.debug("PropheticBuffer prefetch error (non-fatal): %s", exc)
             finally:
@@ -184,12 +214,22 @@ class PropheticBuffer:
 
     async def get_prefetched_text(self, intent_id: str) -> str | None:
         try:
-            return await self._cache.get(f"ironclad:prophet:{intent_id}:text")
+            value = await self._cache.get(f"ironclad:prophet:{intent_id}:text")
+            if value is not None:
+                self._text_hits += 1
+            else:
+                self._text_misses += 1
+            return value
         except Exception:
             return None
 
     async def get_prefetched_audio(self, intent_id: str) -> str | None:
         try:
-            return await self._cache.get(f"ironclad:prophet:{intent_id}:audio")
+            value = await self._cache.get(f"ironclad:prophet:{intent_id}:audio")
+            if value is not None:
+                self._audio_hits += 1
+            else:
+                self._audio_misses += 1
+            return value
         except Exception:
             return None


### PR DESCRIPTION
## Summary

- Adds in-process hit/miss counters to `PropheticBuffer` (no DB migration, no new dependencies)
- Exposes a new `GET /api/prophetic/stats` endpoint that returns a live snapshot of prefetch performance
- Marks the backlog item in `.github/TODO.md` complete

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactor / cleanup
- [ ] Schema / migration change
- [ ] Infrastructure / Docker change
- [x] Governance / docs update
- [ ] Tests

Wait — this **is** a new feature (observability endpoint):
- [x] New feature (non-breaking, purely additive)

## What Was Delivered

### `orchestrator/services/prophetic_buffer.py`

Six new counters added to `__init__` (asyncio single-threaded — no lock required):

| Counter | Tracks |
|---|---|
| `_prefetch_count` | Successful background prefetch runs |
| `_drop_count` | Queue-full drops (backpressure events) |
| `_text_hits` | `get_prefetched_text()` cache hits |
| `_text_misses` | `get_prefetched_text()` cache misses |
| `_audio_hits` | `get_prefetched_audio()` cache hits |
| `_audio_misses` | `get_prefetched_audio()` cache misses |

New `stats()` method returns:
```json
{
  "prefetch_count": 42,
  "drop_count": 0,
  "queue_depth": 0,
  "is_busy": false,
  "text":  { "hits": 31, "misses": 11, "hit_rate": 0.7381 },
  "audio": { "hits": 39, "misses": 3,  "hit_rate": 0.9286 }
}
```

`enqueue()` now increments `_drop_count` on `QueueFull`.
`_worker()` increments `_prefetch_count` after each successful prefetch.
`get_prefetched_text/audio()` increment the appropriate hit/miss counter on every pipeline lookup.

### `orchestrator/main.py`

```
GET /api/prophetic/stats
```

Returns `prophetic_buffer.stats()` directly. No auth required (same pattern as `/health`). No DB call.

### `.github/TODO.md`

Backlog item marked `[x]`:
```
- [x] PropheticBuffer — expose cache hit rate via `/api/prophetic/stats` endpoint
```

## Pre-Merge Checklist

### Targeting & Branching
- [x] Source branch is prefixed `claude/`

### Schema Contract
- [x] No changes to `orchestrator/schemas/payloads.py`
- [x] No raw dicts passed between pipeline phases

### Database
- [x] No schema changes — no migration required

### AI / LLM Rules
- [x] No LLM calls added

### Breaking Changes
- None — all new code. No existing behaviour modified.

## Deployment Notes

No migration. No restart ceremony beyond the normal rolling deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxe8YGoM1HVrBcV2xACxrR)_