### PR TITLE
test(prompts+schemas): unit test coverage for guardrails, gm_prompts, immersion_prompts, payloads

### DIFF
--- a/orchestrator/tests/test_prompts_gm.py
+++ b/orchestrator/tests/test_prompts_gm.py
@@ -1,0 +1,499 @@
+"""
+Unit tests for orchestrator/prompts/gm_prompts.py
+
+Tests cover:
+  - STRUCTURAL_PATTERNS regex list (should match / should not match)
+  - BRAND_BLOCKLIST content assertions
+  - SUBAGENT_PROMPT_TEMPLATES registry completeness
+  - GM_PLANNING_PROMPT template rendering
+  - GM_SYNTHESIS_PROMPT template rendering
+  - Per-task SUBAGENT_*_PROMPT template rendering
+  - MUSIC_SCENE_PROMPTS coverage
+  - GM_DIRECTIVE_BLOCK / GM_STAT_CHANGE_BLOCK rendering
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from orchestrator.prompts.gm_prompts import (
+    BRAND_BLOCKLIST,
+    GM_DIRECTIVE_BLOCK,
+    GM_PLANNING_PROMPT,
+    GM_STAT_CHANGE_BLOCK,
+    GM_SYNTHESIS_PROMPT,
+    GM_SYSTEM_PROMPT,
+    MUSIC_SCENE_PROMPTS,
+    STRUCTURAL_PATTERNS,
+    SUBAGENT_COMBAT_FLAVOUR_PROMPT,
+    SUBAGENT_ENVIRONMENT_PROMPT,
+    SUBAGENT_ITEM_DESCRIPTION_PROMPT,
+    SUBAGENT_NPC_DIALOGUE_PROMPT,
+    SUBAGENT_PROMPT_TEMPLATES,
+    SUBAGENT_SCENE_DESCRIBER_PROMPT,
+    SUBAGENT_SOUND_DIRECTOR_PROMPT,
+    SUBAGENT_SYSTEM_PROMPT,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GM_SYSTEM_PROMPT integrity
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGMSystemPrompt:
+    def test_immersion_rules_present(self):
+        assert "ABSOLUTE IMMERSION RULES" in GM_SYSTEM_PROMPT
+
+    def test_anti_railroading_present(self):
+        assert "ANTI-RAILROADING MANDATE" in GM_SYSTEM_PROMPT
+
+    def test_zero_fourth_wall_breaks(self):
+        assert "FOURTH-WALL" in GM_SYSTEM_PROMPT
+
+    def test_zero_real_world_brands(self):
+        assert "REAL-WORLD BRANDS" in GM_SYSTEM_PROMPT
+
+    def test_player_agency_lock(self):
+        assert "PLAYER AGENCY LOCK" in GM_SYSTEM_PROMPT
+
+    def test_is_non_empty_string(self):
+        assert isinstance(GM_SYSTEM_PROMPT, str)
+        assert len(GM_SYSTEM_PROMPT) > 200
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STRUCTURAL_PATTERNS — patterns that SHOULD match (structural text)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestStructuralPatternsMatch:
+    def _any_match(self, text: str) -> bool:
+        return any(p.search(text) for p in STRUCTURAL_PATTERNS)
+
+    def test_matches_markdown_h2(self):
+        assert self._any_match("## Scene Description")
+
+    def test_matches_markdown_h1(self):
+        assert self._any_match("# Chapter One")
+
+    def test_matches_chapter_heading(self):
+        assert self._any_match("Chapter 3 The Dark Forest")
+
+    def test_matches_section_heading(self):
+        assert self._any_match("Section 2 Overview")
+
+    def test_matches_part_heading(self):
+        assert self._any_match("Part 1 Introduction")
+
+    def test_matches_equals_divider(self):
+        assert self._any_match("=== Scene Break ===")
+
+    def test_matches_dash_divider(self):
+        assert self._any_match("---")
+
+    def test_matches_asterisk_divider(self):
+        assert self._any_match("***")
+
+    def test_matches_numbered_list_item(self):
+        assert self._any_match("1. The guard steps forward")
+
+    def test_matches_dash_bullet(self):
+        assert self._any_match("- The door creaks open")
+
+    def test_matches_asterisk_bullet(self):
+        assert self._any_match("* The torch flickers")
+
+    def test_matches_bullet_point_char(self):
+        assert self._any_match("• An arrow whistles past")
+
+
+class TestStructuralPatternsNoMatch:
+    """Ensure prose that looks slightly structural does NOT match."""
+
+    def _any_match(self, text: str) -> bool:
+        return any(p.search(text) for p in STRUCTURAL_PATTERNS)
+
+    def test_no_match_plain_prose(self):
+        assert not self._any_match(
+            "You step into the shadow of the mountain and feel the cold air on your face."
+        )
+
+    def test_no_match_sentence_with_number(self):
+        assert not self._any_match("You have 3 torches left in your pack.")
+
+    def test_no_match_npc_dialogue(self):
+        assert not self._any_match('"Get out of my tavern," the barkeep growls.')
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BRAND_BLOCKLIST content
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestBrandBlocklist:
+    def test_is_list(self):
+        assert isinstance(BRAND_BLOCKLIST, list)
+
+    def test_non_empty(self):
+        assert len(BRAND_BLOCKLIST) >= 50
+
+    def test_contains_tech_brands(self):
+        lower = [b.lower() for b in BRAND_BLOCKLIST]
+        for brand in ("google", "amazon", "microsoft", "apple"):
+            assert brand in lower, f"Expected '{brand}' in blocklist"
+
+    def test_contains_social_media(self):
+        lower = [b.lower() for b in BRAND_BLOCKLIST]
+        for brand in ("facebook", "twitter", "instagram"):
+            assert brand in lower, f"Expected '{brand}' in blocklist"
+
+    def test_contains_fast_food(self):
+        lower = [b.lower() for b in BRAND_BLOCKLIST]
+        assert any("mcdonald" in b for b in lower)
+
+    def test_contains_real_world_ip(self):
+        lower = [b.lower() for b in BRAND_BLOCKLIST]
+        assert any("star wars" in b for b in lower)
+
+    def test_all_entries_are_strings(self):
+        assert all(isinstance(b, str) for b in BRAND_BLOCKLIST)
+
+    def test_no_empty_strings(self):
+        assert all(len(b.strip()) > 0 for b in BRAND_BLOCKLIST)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUBAGENT_PROMPT_TEMPLATES registry
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSubagentPromptTemplates:
+    REQUIRED_TASK_TYPES = {
+        "npc_dialogue",
+        "environmental_description",
+        "combat_flavour",
+        "item_description",
+        "sound_director",
+        "scene_describer",
+    }
+
+    def test_all_required_types_present(self):
+        for task_type in self.REQUIRED_TASK_TYPES:
+            assert task_type in SUBAGENT_PROMPT_TEMPLATES, (
+                f"Missing task type: {task_type}"
+            )
+
+    def test_values_are_non_empty_strings(self):
+        for key, tmpl in SUBAGENT_PROMPT_TEMPLATES.items():
+            assert isinstance(tmpl, str) and len(tmpl) > 0, (
+                f"Template for '{key}' is empty"
+            )
+
+    def test_npc_dialogue_maps_to_correct_template(self):
+        assert SUBAGENT_PROMPT_TEMPLATES["npc_dialogue"] is SUBAGENT_NPC_DIALOGUE_PROMPT
+
+    def test_environmental_description_maps_to_correct_template(self):
+        assert SUBAGENT_PROMPT_TEMPLATES["environmental_description"] is SUBAGENT_ENVIRONMENT_PROMPT
+
+    def test_combat_flavour_maps_to_correct_template(self):
+        assert SUBAGENT_PROMPT_TEMPLATES["combat_flavour"] is SUBAGENT_COMBAT_FLAVOUR_PROMPT
+
+    def test_item_description_maps_to_correct_template(self):
+        assert SUBAGENT_PROMPT_TEMPLATES["item_description"] is SUBAGENT_ITEM_DESCRIPTION_PROMPT
+
+    def test_sound_director_maps_to_correct_template(self):
+        assert SUBAGENT_PROMPT_TEMPLATES["sound_director"] is SUBAGENT_SOUND_DIRECTOR_PROMPT
+
+    def test_scene_describer_maps_to_correct_template(self):
+        assert SUBAGENT_PROMPT_TEMPLATES["scene_describer"] is SUBAGENT_SCENE_DESCRIBER_PROMPT
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUBAGENT_SYSTEM_PROMPT
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSubagentSystemPrompt:
+    def test_uncensored_mode_declared(self):
+        assert "UNCENSORED" in SUBAGENT_SYSTEM_PROMPT
+
+    def test_no_brand_names_rule(self):
+        assert "brand" in SUBAGENT_SYSTEM_PROMPT.lower()
+
+    def test_no_structural_formatting_rule(self):
+        assert "structural formatting" in SUBAGENT_SYSTEM_PROMPT.lower()
+
+    def test_is_string(self):
+        assert isinstance(SUBAGENT_SYSTEM_PROMPT, str)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Per-task subagent prompt rendering
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSubagentNpcDialoguePrompt:
+    def _render(self, **kw):
+        defaults = dict(
+            entity_name="Grimshaw",
+            entity_role="corrupt city guard",
+            scene_context="A dark alley at midnight, rain falling.",
+            player_action_context="Player accused the guard of taking bribes.",
+            tone="menacing",
+            max_words=80,
+        )
+        defaults.update(kw)
+        return SUBAGENT_NPC_DIALOGUE_PROMPT.format(**defaults)
+
+    def test_entity_name_injected(self):
+        assert "Grimshaw" in self._render()
+
+    def test_entity_role_injected(self):
+        assert "corrupt city guard" in self._render()
+
+    def test_tone_injected(self):
+        assert "menacing" in self._render()
+
+    def test_word_limit_injected(self):
+        assert "80" in self._render()
+
+    def test_player_action_context_injected(self):
+        assert "bribes" in self._render()
+
+
+class TestSubagentEnvironmentPrompt:
+    def _render(self, **kw):
+        defaults = dict(
+            entity_name="The Whispering Vault",
+            entity_role="ancient subterranean crypt",
+            scene_context="First entry into the dungeon.",
+            player_action_context="Player opened the heavy stone door.",
+            tone="fearful",
+            max_words=100,
+        )
+        defaults.update(kw)
+        return SUBAGENT_ENVIRONMENT_PROMPT.format(**defaults)
+
+    def test_location_injected(self):
+        assert "Whispering Vault" in self._render()
+
+    def test_tone_injected(self):
+        assert "fearful" in self._render()
+
+    def test_catalyst_injected(self):
+        assert "stone door" in self._render()
+
+
+class TestSubagentCombatFlavourPrompt:
+    def _render(self, **kw):
+        defaults = dict(
+            entity_name="Serrated Longsword",
+            entity_role="character's primary weapon",
+            scene_context="Melee combat against a bandit chief.",
+            player_action_context="Player declared an overhead strike.",
+            tone="gritty",
+            max_words=60,
+        )
+        defaults.update(kw)
+        return SUBAGENT_COMBAT_FLAVOUR_PROMPT.format(**defaults)
+
+    def test_weapon_name_injected(self):
+        assert "Serrated Longsword" in self._render()
+
+    def test_tone_injected(self):
+        assert "gritty" in self._render()
+
+
+class TestSubagentItemDescriptionPrompt:
+    def _render(self, **kw):
+        defaults = dict(
+            entity_name="Obsidian Amulet",
+            entity_role="magical focus artifact",
+            scene_context="Player searches a fallen wizard's body.",
+            player_action_context="Player picks up the amulet for close inspection.",
+            tone="reverent",
+            max_words=70,
+        )
+        defaults.update(kw)
+        return SUBAGENT_ITEM_DESCRIPTION_PROMPT.format(**defaults)
+
+    def test_item_name_injected(self):
+        assert "Obsidian Amulet" in self._render()
+
+    def test_discovery_context_injected(self):
+        assert "inspection" in self._render()
+
+
+class TestSubagentSoundDirectorPrompt:
+    def _render(self, **kw):
+        defaults = dict(
+            scene_context="Player enters a burning building.",
+            player_action_context="Kicks down the door.",
+            tone="tense",
+        )
+        defaults.update(kw)
+        return SUBAGENT_SOUND_DIRECTOR_PROMPT.format(**defaults)
+
+    def test_json_array_instruction_present(self):
+        result = self._render()
+        assert "JSON" in result
+
+    def test_max_sfx_rule_present(self):
+        result = self._render()
+        assert "3" in result
+
+    def test_scene_context_injected(self):
+        assert "burning building" in self._render()
+
+
+class TestSubagentSceneDescriberPrompt:
+    def _render(self, **kw):
+        defaults = dict(
+            scene_context="A sunlit market square in a fantasy city.",
+            player_action_context="Player looks around after emerging from the sewers.",
+            tone="humorous",
+        )
+        defaults.update(kw)
+        return SUBAGENT_SCENE_DESCRIBER_PROMPT.format(**defaults)
+
+    def test_image_prompt_instruction_present(self):
+        result = self._render()
+        assert "image" in result.lower()
+
+    def test_scene_context_injected(self):
+        assert "market square" in self._render()
+
+    def test_no_brand_rule_present(self):
+        assert "brand" in self._render().lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GM_PLANNING_PROMPT template rendering
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGMPlanningPromptRendering:
+    def _render(self):
+        return GM_PLANNING_PROMPT.format(
+            player_action="I search the bookshelves for a hidden lever.",
+            mechanical_outcome="partial_success — found a clue but triggered a trap",
+            npc_list="None present",
+            environment_type="study/library",
+        )
+
+    def test_player_action_present(self):
+        assert "hidden lever" in self._render()
+
+    def test_mechanical_outcome_present(self):
+        assert "partial_success" in self._render()
+
+    def test_environment_type_present(self):
+        assert "study/library" in self._render()
+
+    def test_task_type_options_documented(self):
+        result = self._render()
+        for tt in ("npc_dialogue", "environmental_description", "combat_flavour", "item_description"):
+            assert tt in result
+
+    def test_tone_options_documented(self):
+        result = self._render()
+        for tone in ("gritty", "menacing", "humorous", "reverent"):
+            assert tone in result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GM_SYNTHESIS_PROMPT template rendering
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGMSynthesisPromptRendering:
+    def _render(self, directive_block="", stat_change_block=""):
+        return GM_SYNTHESIS_PROMPT.format(
+            directive_block=directive_block,
+            mechanical_context='{"outcome":"success"}',
+            story_context="The keep has been besieged for three days.",
+            player_action="I charge through the gates.",
+            assembled_elements="NPC shouts: 'The gates are breached!'",
+            direct_elements="The portcullis falls behind you.",
+            stat_change_block=stat_change_block,
+        )
+
+    def test_mechanical_context_injected(self):
+        assert "success" in self._render()
+
+    def test_story_context_injected(self):
+        assert "besieged" in self._render()
+
+    def test_player_action_injected(self):
+        assert "charge through" in self._render()
+
+    def test_assembled_elements_injected(self):
+        assert "gates are breached" in self._render()
+
+    def test_direct_elements_injected(self):
+        assert "portcullis" in self._render()
+
+    def test_anti_railroading_reminder_in_synthesis(self):
+        assert "Anti-railroading" in self._render() or "anti-railroading" in self._render()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GM_DIRECTIVE_BLOCK rendering
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGMDirectiveBlock:
+    def test_directive_text_injected(self):
+        directive = "Have the innkeeper reveal the spy's identity during small talk."
+        result = GM_DIRECTIVE_BLOCK.format(directives=directive)
+        assert directive in result
+
+    def test_highest_priority_label_present(self):
+        result = GM_DIRECTIVE_BLOCK.format(directives="test directive")
+        assert "HIGHEST PRIORITY" in result
+
+    def test_world_architect_label_present(self):
+        result = GM_DIRECTIVE_BLOCK.format(directives="test")
+        assert "WORLD ARCHITECT" in result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GM_STAT_CHANGE_BLOCK rendering
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGMStatChangeBlock:
+    def test_changes_injected(self):
+        changes = "HP: 24 → 16 (lost 8 from goblin strike)\nGold: 10 → 7"
+        result = GM_STAT_CHANGE_BLOCK.format(changes=changes)
+        assert "HP: 24 → 16" in result
+        assert "Gold: 10 → 7" in result
+
+    def test_mandatory_inclusion_label_present(self):
+        result = GM_STAT_CHANGE_BLOCK.format(changes="HP: 10 → 5")
+        assert "MANDATORY INCLUSION" in result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MUSIC_SCENE_PROMPTS
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestMusicScenePrompts:
+    REQUIRED_SCENES = {"combat", "exploration", "social", "tension", "rest"}
+
+    def test_all_required_scenes_present(self):
+        for scene in self.REQUIRED_SCENES:
+            assert scene in MUSIC_SCENE_PROMPTS, f"Missing scene: {scene}"
+
+    def test_values_are_non_empty_strings(self):
+        for key, val in MUSIC_SCENE_PROMPTS.items():
+            assert isinstance(val, str) and len(val) > 0, f"Empty prompt for '{key}'"
+
+    def test_combat_mentions_tempo(self):
+        assert "bpm" in MUSIC_SCENE_PROMPTS["combat"].lower()
+
+    def test_exploration_mentions_wonder(self):
+        assert "discovery" in MUSIC_SCENE_PROMPTS["exploration"].lower() or \
+               "wonder" in MUSIC_SCENE_PROMPTS["exploration"].lower()
+
+    def test_tension_mentions_suspense(self):
+        assert "suspense" in MUSIC_SCENE_PROMPTS["tension"].lower() or \
+               "tense" in MUSIC_SCENE_PROMPTS["tension"].lower()
+
+    def test_rest_mentions_peaceful(self):
+        assert "peaceful" in MUSIC_SCENE_PROMPTS["rest"].lower() or \
+               "calm" in MUSIC_SCENE_PROMPTS["rest"].lower() or \
+               "soft" in MUSIC_SCENE_PROMPTS["rest"].lower()

--- a/orchestrator/tests/test_prompts_guardrails.py
+++ b/orchestrator/tests/test_prompts_guardrails.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for orchestrator/prompts/guardrails.py
+
+Tests cover:
+  - build_narrative_system_prompt (Gemini path)
+  - build_local_narrative_prompt  (local Ollama path)
+  - MECHANICAL_SYSTEM_PROMPT constant integrity
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.prompts.guardrails import (
+    MECHANICAL_SYSTEM_PROMPT,
+    build_local_narrative_prompt,
+    build_narrative_system_prompt,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MECHANICAL_SYSTEM_PROMPT constant
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestMechanicalSystemPrompt:
+    def test_contains_anti_sycophancy_lock(self):
+        assert "ANTI-SYCOPHANCY LOCK" in MECHANICAL_SYSTEM_PROMPT
+
+    def test_contains_dice_supremacy_lock(self):
+        assert "DICE SUPREMACY LOCK" in MECHANICAL_SYSTEM_PROMPT
+
+    def test_contains_narrative_prohibition(self):
+        assert "NARRATIVE PROHIBITION" in MECHANICAL_SYSTEM_PROMPT
+
+    def test_contains_json_output_format(self):
+        assert "OUTPUT FORMAT" in MECHANICAL_SYSTEM_PROMPT
+        assert "OllamaResolutionPayload" in MECHANICAL_SYSTEM_PROMPT
+
+    def test_contains_vehicle_rules(self):
+        assert "VEHICLE RULES" in MECHANICAL_SYSTEM_PROMPT
+        assert "vehicle_deltas" in MECHANICAL_SYSTEM_PROMPT
+
+    def test_is_non_empty_string(self):
+        assert isinstance(MECHANICAL_SYSTEM_PROMPT, str)
+        assert len(MECHANICAL_SYSTEM_PROMPT) > 500
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# build_narrative_system_prompt (Gemini / cloud path)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestBuildNarrativeSystemPrompt:
+    def _build(self, system="D&D 5e", truth='{"outcome":"success"}', lines=None, tone=""):
+        return build_narrative_system_prompt(
+            system=system,
+            mechanical_truth_json=truth,
+            story_context_lines=lines,
+            world_tone_block=tone,
+        )
+
+    def test_system_name_injected(self):
+        result = self._build(system="Mothership")
+        assert "Mothership" in result
+
+    def test_mechanical_truth_injected(self):
+        truth = '{"outcome":"critical_failure","roll_result":2}'
+        result = self._build(truth=truth)
+        assert truth in result
+
+    def test_no_story_context_uses_opening_scene_placeholder(self):
+        result = self._build(lines=None)
+        assert "opening scene" in result.lower()
+
+    def test_story_context_lines_injected_as_bullets(self):
+        lines = ["The tavern burned down last session", "Aldric the merchant is dead"]
+        result = self._build(lines=lines)
+        assert "• The tavern burned down last session" in result
+        assert "• Aldric the merchant is dead" in result
+
+    def test_empty_story_context_list_uses_placeholder(self):
+        result = self._build(lines=[])
+        assert "opening scene" in result.lower()
+
+    def test_world_tone_block_prepended(self):
+        tone = "GENRE: Grimdark pirate horror. Tone is bleak and unrelenting."
+        result = self._build(tone=tone)
+        assert result.startswith(tone)
+
+    def test_world_tone_block_empty_not_prepended(self):
+        result = self._build(tone="")
+        assert not result.startswith("\n")
+        assert "ROLE:" in result[:50]
+
+    def test_mechanical_truth_lock_present(self):
+        result = self._build()
+        assert "MECHANICAL TRUTH LOCK" in result
+
+    def test_story_continuity_lock_present(self):
+        result = self._build()
+        assert "STORY CONTINUITY LOCK" in result
+
+    def test_anti_sycophancy_lock_present(self):
+        result = self._build()
+        assert "ANTI-SYCOPHANCY LOCK" in result
+
+    def test_lethal_outcome_protocol_present(self):
+        result = self._build()
+        assert "LETHAL OUTCOME PROTOCOL" in result
+
+    def test_anti_railroading_mandate_present(self):
+        result = self._build()
+        assert "ANTI-RAILROADING MANDATE" in result
+
+    def test_returns_string(self):
+        assert isinstance(self._build(), str)
+
+    def test_tone_and_context_combined(self):
+        tone = "SETTING: Space western."
+        lines = ["The ship is named The Vagrant Star"]
+        result = self._build(tone=tone, lines=lines)
+        assert result.startswith(tone)
+        assert "The ship is named The Vagrant Star" in result
+
+    def test_multiple_story_lines_all_present(self):
+        lines = [f"Fact {i}" for i in range(5)]
+        result = self._build(lines=lines)
+        for line in lines:
+            assert line in result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# build_local_narrative_prompt (local Ollama / uncensored path)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestBuildLocalNarrativePrompt:
+    def _build(self, system="Call of Cthulhu", truth='{"outcome":"failure"}', lines=None, tone=""):
+        return build_local_narrative_prompt(
+            system=system,
+            mechanical_truth_json=truth,
+            story_context_lines=lines,
+            world_tone_block=tone,
+        )
+
+    def test_system_name_injected(self):
+        assert "Call of Cthulhu" in self._build()
+
+    def test_mechanical_truth_injected(self):
+        truth = '{"roll_result":3}'
+        assert truth in self._build(truth=truth)
+
+    def test_uncensored_mode_present(self):
+        result = self._build()
+        assert "UNCENSORED" in result.upper()
+
+    def test_no_story_context_uses_placeholder(self):
+        result = self._build(lines=None)
+        assert "opening scene" in result.lower()
+
+    def test_story_context_lines_become_bullets(self):
+        lines = ["The lighthouse keeper vanished", "Strange lights at sea"]
+        result = self._build(lines=lines)
+        assert "• The lighthouse keeper vanished" in result
+        assert "• Strange lights at sea" in result
+
+    def test_world_tone_prepended(self):
+        tone = "COSMIC HORROR: reality frays at every turn."
+        result = self._build(tone=tone)
+        assert result.startswith(tone)
+
+    def test_no_tone_result_starts_with_role(self):
+        result = self._build(tone="")
+        assert "ROLE:" in result[:60]
+
+    def test_mechanical_truth_lock_present(self):
+        assert "MECHANICAL TRUTH LOCK" in self._build()
+
+    def test_anti_railroading_present(self):
+        assert "ANTI-RAILROADING MANDATE" in self._build()
+
+    def test_returns_string(self):
+        assert isinstance(self._build(), str)
+
+    def test_local_and_gemini_differ_by_uncensored(self):
+        truth = '{"x":1}'
+        local = build_local_narrative_prompt("D&D 5e", truth, None, "")
+        gemini = build_narrative_system_prompt("D&D 5e", truth, None, "")
+        # local has uncensored grant; gemini does not
+        assert "UNCENSORED" in local.upper()
+        # both share core constraints
+        assert "MECHANICAL TRUTH LOCK" in local
+        assert "MECHANICAL TRUTH LOCK" in gemini

--- a/orchestrator/tests/test_prompts_immersion.py
+++ b/orchestrator/tests/test_prompts_immersion.py
@@ -1,0 +1,450 @@
+"""
+Unit tests for orchestrator/prompts/immersion_prompts.py
+
+Tests cover:
+  - is_combat_action()
+  - is_combat_end()
+  - detect_channel_directive()
+  - build_thread_content()
+  - AMBIENT_AUDIO_MAP content
+  - WHISPER_SYSTEM_PROMPT / WHISPER_PROMPT constants
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from orchestrator.prompts.immersion_prompts import (
+    AMBIENT_AUDIO_MAP,
+    WHISPER_PROMPT,
+    WHISPER_SYSTEM_PROMPT,
+    build_thread_content,
+    detect_channel_directive,
+    is_combat_action,
+    is_combat_end,
+)
+from orchestrator.schemas.payloads import (
+    ActionOutcome,
+    CharacterStatus,
+    DiceRequest,
+    OllamaResolutionPayload,
+    StateDelta,
+    StatDelta,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_resolution(
+    action_type: str = "melee_attack",
+    difficulty: int = 12,
+    notation: str = "1d20",
+    modifier: int = 2,
+    roll_result: int = 15,
+    outcome: ActionOutcome = ActionOutcome.SUCCESS,
+    stat_deltas=None,
+    status_change=None,
+    inventory_delta=None,
+    citations=None,
+    reasoning: str = "Attack connects.",
+    intent_id: str = "intent-001",
+) -> OllamaResolutionPayload:
+    return OllamaResolutionPayload(
+        intent_id=intent_id,
+        action_type=action_type,
+        difficulty=difficulty,
+        dice_request=DiceRequest(notation=notation, modifier=modifier, purpose="attack roll"),
+        roll_result=roll_result,
+        outcome=outcome,
+        state_delta=StateDelta(
+            character_id="char-001",
+            stat_deltas=stat_deltas or [],
+            status_change=status_change,
+            inventory_delta=inventory_delta or [],
+        ),
+        rulebook_citations=citations or [],
+        reasoning=reasoning,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# is_combat_action()
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestIsCombatAction:
+    def test_melee_attack_is_combat(self):
+        assert is_combat_action("melee_attack") is True
+
+    def test_ranged_is_combat(self):
+        assert is_combat_action("ranged_shot") is True
+
+    def test_shoot_is_combat(self):
+        assert is_combat_action("shoot_crossbow") is True
+
+    def test_stab_is_combat(self):
+        assert is_combat_action("stab_enemy") is True
+
+    def test_slash_is_combat(self):
+        assert is_combat_action("slash_attack") is True
+
+    def test_strike_is_combat(self):
+        assert is_combat_action("power_strike") is True
+
+    def test_dodge_is_combat(self):
+        assert is_combat_action("dodge_roll") is True
+
+    def test_parry_is_combat(self):
+        assert is_combat_action("parry_blow") is True
+
+    def test_grapple_is_combat(self):
+        assert is_combat_action("grapple_opponent") is True
+
+    def test_charge_is_combat(self):
+        assert is_combat_action("charge") is True
+
+    def test_ambush_is_combat(self):
+        assert is_combat_action("ambush_guard") is True
+
+    def test_combat_keyword_is_combat(self):
+        assert is_combat_action("combat_maneuver") is True
+
+    def test_throw_is_combat(self):
+        assert is_combat_action("throw_dagger") is True
+
+    def test_suppress_is_combat(self):
+        assert is_combat_action("suppress_fire") is True
+
+    def test_flank_is_combat(self):
+        assert is_combat_action("flank_enemy") is True
+
+    def test_draw_weapon_is_combat(self):
+        assert is_combat_action("draw_weapon") is True
+
+    def test_reload_is_combat(self):
+        assert is_combat_action("reload_gun") is True
+
+    def test_social_interaction_not_combat(self):
+        assert is_combat_action("social_interaction") is False
+
+    def test_exploration_not_combat(self):
+        assert is_combat_action("exploration") is False
+
+    def test_craft_not_combat(self):
+        assert is_combat_action("craft_potion") is False
+
+    def test_skill_check_not_combat(self):
+        assert is_combat_action("skill_check_stealth") is False
+
+    def test_case_insensitive(self):
+        assert is_combat_action("MELEE_ATTACK") is True
+        assert is_combat_action("Ranged_Shot") is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# is_combat_end()
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestIsCombatEnd:
+    def test_dead_status_ends_combat(self):
+        assert is_combat_end("melee_attack", "", CharacterStatus.DEAD) is True
+
+    def test_flee_action_ends_combat(self):
+        assert is_combat_end("flee", "", None) is True
+
+    def test_escape_action_ends_combat(self):
+        assert is_combat_end("escape", "", None) is True
+
+    def test_surrender_action_ends_combat(self):
+        assert is_combat_end("surrender", "", None) is True
+
+    def test_retreat_action_ends_combat(self):
+        assert is_combat_end("retreat", "", None) is True
+
+    def test_yield_action_ends_combat(self):
+        assert is_combat_end("yield_fight", "", None) is True
+
+    def test_combat_end_action_ends_combat(self):
+        assert is_combat_end("combat_end", "", None) is True
+
+    def test_disengage_action_ends_combat(self):
+        assert is_combat_end("disengage", "", None) is True
+
+    def test_fall_unconscious_action_ends_combat(self):
+        assert is_combat_end("fall_unconscious", "", None) is True
+
+    def test_death_save_action_ends_combat(self):
+        assert is_combat_end("death_save", "", None) is True
+
+    def test_retreat_in_reasoning_ends_combat(self):
+        assert is_combat_end("exploration", "The enemy chose to retreat from battle.", None) is True
+
+    def test_escape_in_reasoning_ends_combat(self):
+        assert is_combat_end("skill_check", "Player managed to escape the ambush.", None) is True
+
+    def test_normal_attack_does_not_end_combat(self):
+        assert is_combat_end("melee_attack", "Attack connects for 8 damage.", None) is False
+
+    def test_social_action_does_not_end_combat(self):
+        assert is_combat_end("social_interaction", "Negotiation attempt.", None) is False
+
+    def test_alive_status_does_not_end_combat(self):
+        assert is_combat_end("melee_attack", "", CharacterStatus.ALIVE) is False
+
+    def test_case_insensitive_action(self):
+        assert is_combat_end("FLEE", "", None) is True
+
+    def test_none_reasoning_does_not_crash(self):
+        assert is_combat_end("melee_attack", None, None) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# detect_channel_directive()
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDetectChannelDirective:
+    def test_captured_triggers_prison(self):
+        action, key = detect_channel_directive(
+            "skill_check", "The player was captured by the guards.", "failure"
+        )
+        assert action == "move_to"
+        assert key in ("dungeon", "prison")
+
+    def test_imprisoned_triggers_prison(self):
+        action, key = detect_channel_directive(
+            "social", "Player was imprisoned for the crime.", "failure"
+        )
+        assert action == "move_to"
+        assert key in ("dungeon", "prison")
+
+    def test_dungeon_keyword_triggers_dungeon(self):
+        action, key = detect_channel_directive(
+            "combat", "Player was thrown into the dungeon and chained.", "failure"
+        )
+        assert action == "move_to"
+        assert key == "dungeon"
+
+    def test_cell_keyword_triggers_dungeon(self):
+        action, key = detect_channel_directive(
+            "skill_check", "Player was locked in a cell underground.", "failure"
+        )
+        assert action == "move_to"
+        assert key == "dungeon"
+
+    def test_pit_keyword_triggers_dungeon(self):
+        action, key = detect_channel_directive(
+            "combat", "Player was thrown into the pit and chained.", "failure"
+        )
+        assert action == "move_to"
+        assert key == "dungeon"
+
+    def test_escaped_triggers_restore(self):
+        action, key = detect_channel_directive(
+            "skill_check", "Player escaped through the window.", "success"
+        )
+        assert action == "restore"
+        assert key == "main"
+
+    def test_freed_triggers_restore(self):
+        action, key = detect_channel_directive(
+            "npc_interaction", "Player was freed by the rebel faction.", "success"
+        )
+        assert action == "restore"
+        assert key == "main"
+
+    def test_breaks_free_triggers_restore(self):
+        action, key = detect_channel_directive(
+            "strength_check", "Player breaks free of the shackles.", "success"
+        )
+        assert action == "restore"
+        assert key == "main"
+
+    def test_escape_checked_before_capture(self):
+        # Both keywords present — escape should win
+        action, key = detect_channel_directive(
+            "action", "Player escaped even though arrested earlier.", "success"
+        )
+        assert action == "restore"
+
+    def test_no_keywords_returns_none_none(self):
+        action, key = detect_channel_directive(
+            "melee_attack", "Attack connects for 8 damage.", "success"
+        )
+        assert action is None
+        assert key is None
+
+    def test_none_reasoning_returns_none_none(self):
+        action, key = detect_channel_directive("melee_attack", None, "success")
+        assert action is None
+        assert key is None
+
+    def test_empty_reasoning_returns_none_none(self):
+        action, key = detect_channel_directive("skill_check", "", "success")
+        assert action is None
+        assert key is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# build_thread_content()
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestBuildThreadContent:
+    def _basic_resolution(self, **kw) -> OllamaResolutionPayload:
+        return _make_resolution(**kw)
+
+    def test_action_type_formatted_in_output(self):
+        res = self._basic_resolution(action_type="melee_attack")
+        result = build_thread_content(res, "Kira")
+        assert "Melee Attack" in result
+
+    def test_roll_result_in_output(self):
+        res = self._basic_resolution(roll_result=17)
+        result = build_thread_content(res, "Kira")
+        assert "17" in result
+
+    def test_difficulty_in_output(self):
+        res = self._basic_resolution(difficulty=14)
+        result = build_thread_content(res, "Kira")
+        assert "14" in result
+
+    def test_character_name_signed_at_end(self):
+        res = self._basic_resolution()
+        result = build_thread_content(res, "BraveHero")
+        assert "BraveHero" in result
+
+    def test_outcome_value_in_output(self):
+        res = self._basic_resolution(outcome=ActionOutcome.CRITICAL_SUCCESS)
+        result = build_thread_content(res, "Kira")
+        assert "CRITICAL SUCCESS" in result.upper()
+
+    def test_stat_deltas_shown(self):
+        deltas = [StatDelta(stat_key="hp", old_value=20, new_value=12)]
+        res = self._basic_resolution(stat_deltas=deltas)
+        result = build_thread_content(res, "Kira")
+        assert "hp" in result
+        assert "20" in result
+        assert "12" in result
+
+    def test_numeric_delta_sign_shown(self):
+        deltas = [StatDelta(stat_key="stamina", old_value=10, new_value=14)]
+        res = self._basic_resolution(stat_deltas=deltas)
+        result = build_thread_content(res, "Kira")
+        assert "+4" in result
+
+    def test_negative_delta_shown(self):
+        deltas = [StatDelta(stat_key="hp", old_value=20, new_value=5)]
+        res = self._basic_resolution(stat_deltas=deltas)
+        result = build_thread_content(res, "Kira")
+        assert "-15" in result
+
+    def test_inventory_delta_shown_when_present(self):
+        inv = [{"name": "Health Potion", "quantity": -1}]
+        res = self._basic_resolution(inventory_delta=inv)
+        result = build_thread_content(res, "Kira")
+        assert "Health Potion" in result
+
+    def test_status_change_shown_when_dead(self):
+        res = self._basic_resolution(status_change=CharacterStatus.DEAD)
+        result = build_thread_content(res, "Kira")
+        assert "DEAD" in result.upper()
+
+    def test_rulebook_citations_shown(self):
+        res = self._basic_resolution(citations=["PHB p.194 – Melee Attack"])
+        result = build_thread_content(res, "Kira")
+        assert "PHB p.194" in result
+
+    def test_reasoning_shown_truncated(self):
+        long_reasoning = "X" * 400
+        res = self._basic_resolution(reasoning=long_reasoning)
+        result = build_thread_content(res, "Kira")
+        assert "X" * 280 in result
+
+    def test_no_stat_deltas_no_stat_section(self):
+        res = self._basic_resolution(stat_deltas=[])
+        result = build_thread_content(res, "Kira")
+        assert "Stat Changes" not in result
+
+    def test_critical_failure_emoji_present(self):
+        res = self._basic_resolution(outcome=ActionOutcome.CRITICAL_FAILURE)
+        result = build_thread_content(res, "Kira")
+        assert "💀" in result
+
+    def test_success_emoji_present(self):
+        res = self._basic_resolution(outcome=ActionOutcome.SUCCESS)
+        result = build_thread_content(res, "Kira")
+        assert "✅" in result
+
+    def test_failure_emoji_present(self):
+        res = self._basic_resolution(outcome=ActionOutcome.FAILURE)
+        result = build_thread_content(res, "Kira")
+        assert "❌" in result
+
+    def test_partial_success_emoji_present(self):
+        res = self._basic_resolution(outcome=ActionOutcome.PARTIAL_SUCCESS)
+        result = build_thread_content(res, "Kira")
+        assert "⚡" in result
+
+    def test_critical_success_emoji_present(self):
+        res = self._basic_resolution(outcome=ActionOutcome.CRITICAL_SUCCESS)
+        result = build_thread_content(res, "Kira")
+        assert "🌟" in result
+
+    def test_max_three_citations_shown(self):
+        res = self._basic_resolution(citations=[f"Cite {i}" for i in range(6)])
+        result = build_thread_content(res, "Kira")
+        assert "Cite 0" in result
+        assert "Cite 2" in result
+        assert "Cite 3" not in result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AMBIENT_AUDIO_MAP
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAmbientAudioMap:
+    def test_combat_maps_to_combat_tension(self):
+        assert AMBIENT_AUDIO_MAP["combat encounter"] == "combat_tension"
+
+    def test_social_maps_to_tavern_chatter(self):
+        assert AMBIENT_AUDIO_MAP["social interaction"] == "tavern_chatter"
+
+    def test_exploration_maps_to_dungeon_ambience(self):
+        assert AMBIENT_AUDIO_MAP["exploration/stealth"] == "dungeon_ambience"
+
+    def test_crafting_maps_to_workshop_sounds(self):
+        assert AMBIENT_AUDIO_MAP["crafting/downtime"] == "workshop_sounds"
+
+    def test_general_scene_maps_to_none(self):
+        assert AMBIENT_AUDIO_MAP["general scene"] is None
+
+    def test_all_values_are_str_or_none(self):
+        for val in AMBIENT_AUDIO_MAP.values():
+            assert val is None or isinstance(val, str)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# WHISPER_SYSTEM_PROMPT / WHISPER_PROMPT constants
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestWhisperPromptConstants:
+    def test_whisper_system_prompt_has_sentence_limit(self):
+        assert "2-3 sentences" in WHISPER_SYSTEM_PROMPT
+
+    def test_whisper_system_prompt_forbids_game_terms(self):
+        lower = WHISPER_SYSTEM_PROMPT.lower()
+        assert "game-mechanical" in lower or "game mechanic" in lower
+
+    def test_whisper_system_prompt_second_person(self):
+        assert "second person" in WHISPER_SYSTEM_PROMPT.lower() or "You notice" in WHISPER_SYSTEM_PROMPT
+
+    def test_whisper_prompt_renders(self):
+        result = WHISPER_PROMPT.format(
+            narrative_summary="The guard escorted you to the gates.",
+            npc_list="Captain Aldric (suspicious), Town Guard (nervous)",
+            mechanical_outcome="partial_success — guard is wary but did not attack",
+        )
+        assert "Aldric" in result
+        assert "partial_success" in result

--- a/orchestrator/tests/test_schemas_payloads.py
+++ b/orchestrator/tests/test_schemas_payloads.py
@@ -1,0 +1,792 @@
+"""
+Unit tests for orchestrator/schemas/payloads.py
+
+Tests cover:
+  - All enum classes (values, membership)
+  - Pydantic model construction and defaults
+  - OllamaResolutionPayload.reasoning_must_be_mechanical() field validator
+  - UUID auto-generation via default_factory
+  - Nested model composition (StateDelta, VehicleDelta, MechanicalTruth, etc.)
+  - Optional / nullable fields
+  - NarrativeResponsePayload Task-4 fields
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from orchestrator.schemas.payloads import (
+    ActionOutcome,
+    CampfireStatus,
+    ChannelDirective,
+    CharacterSnapshot,
+    CharacterStatus,
+    CommandType,
+    ContextAssemblyPayload,
+    DiceRequest,
+    DirectiveType,
+    DowntimeSubmitRequest,
+    DowntimeTaskStatus,
+    ExtractionResult,
+    ExtractedFact,
+    GMDirective,
+    GMDirectiveRequest,
+    GMPlanResult,
+    IntentPayload,
+    MechanicalTruth,
+    MultimediaCue,
+    MultimediaType,
+    MusicCue,
+    NarrativeRequestPayload,
+    NarrativeResponsePayload,
+    OperationalStatus,
+    PipelineResult,
+    PresenceUpdate,
+    RecapRequest,
+    RecapResponse,
+    RetconRequest,
+    RetconResponse,
+    RuleChunk,
+    SFXCue,
+    SlashCommandData,
+    StateCommitPayload,
+    StateDelta,
+    StatDelta,
+    StoryEntityType,
+    StoryFact,
+    SubAgentResult,
+    SubAgentTask,
+    SubsystemDelta,
+    SubsystemSnapshot,
+    ThreadEvent,
+    TTSCue,
+    VehicleDelta,
+    VehicleSnapshot,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Enum completeness
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCommandTypeEnum:
+    def test_has_action(self):
+        assert CommandType.ACTION == "action"
+
+    def test_has_slash_command(self):
+        assert CommandType.SLASH_COMMAND == "slash_command"
+
+    def test_has_ooc(self):
+        assert CommandType.OOC == "ooc"
+
+    def test_three_members(self):
+        assert len(CommandType) == 3
+
+
+class TestCharacterStatusEnum:
+    def test_alive(self):
+        assert CharacterStatus.ALIVE == "ALIVE"
+
+    def test_dead(self):
+        assert CharacterStatus.DEAD == "DEAD"
+
+    def test_retired(self):
+        assert CharacterStatus.RETIRED == "RETIRED"
+
+
+class TestActionOutcomeEnum:
+    EXPECTED = {
+        "CRITICAL_SUCCESS", "SUCCESS", "PARTIAL_SUCCESS", "FAILURE", "CRITICAL_FAILURE"
+    }
+
+    def test_all_members_present(self):
+        names = {m.name for m in ActionOutcome}
+        assert self.EXPECTED == names
+
+    def test_values_are_snake_case(self):
+        for member in ActionOutcome:
+            assert "_" in member.value or member.value.islower()
+
+
+class TestMultimediaTypeEnum:
+    def test_image(self):
+        assert MultimediaType.IMAGE == "image"
+
+    def test_sound_cue(self):
+        assert MultimediaType.SOUND_CUE == "sound_cue"
+
+    def test_ambient(self):
+        assert MultimediaType.AMBIENT == "ambient"
+
+
+class TestOperationalStatusEnum:
+    def test_operational(self):
+        assert OperationalStatus.OPERATIONAL == "OPERATIONAL"
+
+    def test_damaged(self):
+        assert OperationalStatus.DAMAGED == "DAMAGED"
+
+    def test_destroyed(self):
+        assert OperationalStatus.DESTROYED == "DESTROYED"
+
+
+class TestStoryEntityTypeEnum:
+    EXPECTED = {"NPC", "LOCATION", "EVENT", "WORLD_FACT", "PLOT_THREAD"}
+
+    def test_all_members_present(self):
+        assert {m.name for m in StoryEntityType} == self.EXPECTED
+
+
+class TestThreadEventEnum:
+    def test_combat(self):
+        assert ThreadEvent.COMBAT == "combat"
+
+    def test_close(self):
+        assert ThreadEvent.CLOSE == "close"
+
+
+class TestDirectiveTypeEnum:
+    EXPECTED = {
+        "SCENE_DIRECTIVE", "NPC_HINT", "WORLD_EVENT", "PACING_NOTE", "CORRECTION"
+    }
+
+    def test_all_members_present(self):
+        assert {m.name for m in DirectiveType} == self.EXPECTED
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# IntentPayload
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestIntentPayload:
+    def _make(self, **kw):
+        defaults = dict(
+            player_id="111222333",
+            guild_id="444555666",
+            channel_id="777888999",
+            session_token="tok-abc",
+            raw_input="I attack the goblin.",
+        )
+        defaults.update(kw)
+        return IntentPayload(**defaults)
+
+    def test_auto_intent_id_is_uuid(self):
+        payload = self._make()
+        uuid.UUID(payload.intent_id)  # raises ValueError if invalid
+
+    def test_default_command_type_is_action(self):
+        assert self._make().command_type == CommandType.ACTION
+
+    def test_slash_command_defaults_to_none(self):
+        assert self._make().slash_command is None
+
+    def test_timestamp_auto_populated(self):
+        assert isinstance(self._make().timestamp, datetime)
+
+    def test_raw_input_stored(self):
+        assert self._make().raw_input == "I attack the goblin."
+
+    def test_slash_command_populated(self):
+        sc = SlashCommandData(command_name="roll", options={"dice": "1d20"})
+        payload = self._make(command_type=CommandType.SLASH_COMMAND, slash_command=sc)
+        assert payload.slash_command.command_name == "roll"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DiceRequest
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDiceRequest:
+    def test_basic_construction(self):
+        dr = DiceRequest(notation="2d6", modifier=3, purpose="damage roll")
+        assert dr.notation == "2d6"
+        assert dr.modifier == 3
+
+    def test_modifier_defaults_to_zero(self):
+        dr = DiceRequest(notation="1d20")
+        assert dr.modifier == 0
+
+    def test_purpose_defaults_to_empty(self):
+        dr = DiceRequest(notation="1d8")
+        assert dr.purpose == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# StatDelta
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestStatDelta:
+    def test_stores_stat_key_and_values(self):
+        sd = StatDelta(stat_key="hp", old_value=20, new_value=12)
+        assert sd.stat_key == "hp"
+        assert sd.old_value == 20
+        assert sd.new_value == 12
+
+    def test_accepts_non_numeric_values(self):
+        sd = StatDelta(stat_key="status", old_value="alive", new_value="wounded")
+        assert sd.new_value == "wounded"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# StateDelta
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestStateDelta:
+    def test_defaults(self):
+        sd = StateDelta(character_id="char-001")
+        assert sd.stat_deltas == []
+        assert sd.status_change is None
+        assert sd.inventory_delta == []
+        assert sd.vehicle_deltas == []
+
+    def test_stat_deltas_stored(self):
+        delta = StatDelta(stat_key="hp", old_value=10, new_value=5)
+        sd = StateDelta(character_id="c1", stat_deltas=[delta])
+        assert len(sd.stat_deltas) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# OllamaResolutionPayload — field validator
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestOllamaResolutionPayload:
+    def _make(self, reasoning="ok", **kw):
+        defaults = dict(
+            intent_id="intent-001",
+            action_type="melee_attack",
+            difficulty=12,
+            dice_request=DiceRequest(notation="1d20", modifier=2),
+            roll_result=15,
+            outcome=ActionOutcome.SUCCESS,
+            state_delta=StateDelta(character_id="char-001"),
+            reasoning=reasoning,
+        )
+        defaults.update(kw)
+        from orchestrator.schemas.payloads import OllamaResolutionPayload
+        return OllamaResolutionPayload(**defaults)
+
+    def test_auto_resolution_id_is_uuid(self):
+        uuid.UUID(self._make().resolution_id)
+
+    def test_reasoning_under_500_chars_stored_as_is(self):
+        r = self._make(reasoning="Short reasoning.")
+        assert r.reasoning == "Short reasoning."
+
+    def test_reasoning_over_500_chars_truncated(self):
+        long = "X" * 600
+        r = self._make(reasoning=long)
+        assert len(r.reasoning) == 500
+        assert r.reasoning == "X" * 500
+
+    def test_reasoning_exactly_500_chars_not_truncated(self):
+        exact = "Y" * 500
+        r = self._make(reasoning=exact)
+        assert r.reasoning == exact
+
+    def test_difficulty_must_be_at_least_1(self):
+        with pytest.raises(ValidationError):
+            self._make(difficulty=0)
+
+    def test_rulebook_citations_default_empty(self):
+        assert self._make().rulebook_citations == []
+
+    def test_resolved_at_auto_populated(self):
+        assert isinstance(self._make().resolved_at, datetime)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# VehicleDelta / SubsystemDelta
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestVehicleDelta:
+    def test_defaults(self):
+        vd = VehicleDelta(vehicle_id="v-001")
+        assert vd.hull_delta == 0
+        assert vd.subsystems == []
+
+    def test_negative_hull_delta_allowed(self):
+        vd = VehicleDelta(vehicle_id="v-001", hull_delta=-30)
+        assert vd.hull_delta == -30
+
+    def test_subsystem_delta_stored(self):
+        sd = SubsystemDelta(
+            subsystem_name="Engine",
+            new_status=OperationalStatus.DAMAGED,
+        )
+        vd = VehicleDelta(vehicle_id="v-001", subsystems=[sd])
+        assert vd.subsystems[0].subsystem_name == "Engine"
+
+
+class TestSubsystemDelta:
+    def test_defaults(self):
+        sd = SubsystemDelta(subsystem_name="Turret")
+        assert sd.new_status is None
+        assert sd.assigned_character_id == "__no_change__"
+
+    def test_unassign_with_none(self):
+        sd = SubsystemDelta(subsystem_name="Helm", assigned_character_id=None)
+        assert sd.assigned_character_id is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# StateCommitPayload
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestStateCommitPayload:
+    def test_auto_commit_id_is_uuid(self):
+        sc = StateCommitPayload(
+            intent_id="i-001",
+            character_id="c-001",
+            pre_state={"hp": 20},
+            post_state={"hp": 12},
+        )
+        uuid.UUID(sc.commit_id)
+
+    def test_lethal_defaults_false(self):
+        sc = StateCommitPayload(
+            intent_id="i-001",
+            character_id="c-001",
+            pre_state={},
+            post_state={},
+        )
+        assert sc.lethal is False
+
+    def test_lethal_set_true(self):
+        sc = StateCommitPayload(
+            intent_id="i-001",
+            character_id="c-001",
+            pre_state={},
+            post_state={},
+            lethal=True,
+        )
+        assert sc.lethal is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MechanicalTruth
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestMechanicalTruth:
+    def test_construction(self):
+        mt = MechanicalTruth(
+            action_type="melee_attack",
+            difficulty=15,
+            dice_notation="1d20+3",
+            roll_result=18,
+            outcome=ActionOutcome.SUCCESS,
+            stat_changes=[],
+            status_change=None,
+            rulebook_citations=["PHB p.194"],
+        )
+        assert mt.roll_result == 18
+        assert mt.outcome == ActionOutcome.SUCCESS
+
+    def test_optional_status_change(self):
+        mt = MechanicalTruth(
+            action_type="attack",
+            difficulty=10,
+            dice_notation="1d20",
+            roll_result=5,
+            outcome=ActionOutcome.FAILURE,
+            stat_changes=[],
+            status_change=None,
+            rulebook_citations=[],
+        )
+        assert mt.status_change is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# NarrativeResponsePayload (Task-4 fields)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestNarrativeResponsePayload:
+    def _make(self, **kw):
+        defaults = dict(
+            prompt_id="p-001",
+            intent_id="i-001",
+            narrative="You swing your sword and the goblin falls.",
+        )
+        defaults.update(kw)
+        return NarrativeResponsePayload(**defaults)
+
+    def test_basic_construction(self):
+        payload = self._make()
+        assert payload.narrative.startswith("You swing")
+
+    def test_whisper_defaults_none(self):
+        assert self._make().whisper is None
+
+    def test_thread_event_defaults_none(self):
+        assert self._make().thread_event is None
+
+    def test_ambient_audio_key_defaults_none(self):
+        assert self._make().ambient_audio_key is None
+
+    def test_tts_cues_defaults_empty(self):
+        assert self._make().tts_cues == []
+
+    def test_sfx_cues_defaults_empty(self):
+        assert self._make().sfx_cues == []
+
+    def test_channel_directive_defaults_none(self):
+        assert self._make().channel_directive is None
+
+    def test_music_cue_defaults_none(self):
+        assert self._make().music_cue is None
+
+    def test_whisper_set(self):
+        payload = self._make(whisper="You notice the guard's hand trembling.")
+        assert "trembling" in payload.whisper
+
+    def test_thread_event_combat(self):
+        payload = self._make(thread_event=ThreadEvent.COMBAT)
+        assert payload.thread_event == ThreadEvent.COMBAT
+
+    def test_channel_directive_set(self):
+        cd = ChannelDirective(action="move_to", channel_key="dungeon", reason="arrested")
+        payload = self._make(channel_directive=cd)
+        assert payload.channel_directive.channel_key == "dungeon"
+
+    def test_tts_cues_stored(self):
+        cue = TTSCue(entity_name="Guard", text="Halt!", voice_id="en-US-GuyNeural")
+        payload = self._make(tts_cues=[cue])
+        assert payload.tts_cues[0].entity_name == "Guard"
+
+    def test_music_cue_stored(self):
+        cue = MusicCue(scene_type="combat", music_prompt="intense drums, 160bpm")
+        payload = self._make(music_cue=cue)
+        assert payload.music_cue.scene_type == "combat"
+
+    def test_driftnet_channel_id_defaults_empty(self):
+        assert self._make().driftnet_channel_id == ""
+
+    def test_generated_at_auto_populated(self):
+        assert isinstance(self._make().generated_at, datetime)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TTSCue
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestTTSCue:
+    def test_defaults(self):
+        cue = TTSCue(entity_name="Innkeeper", text="Welcome, traveller.")
+        assert cue.voice_id == "en-US-GuyNeural"
+        assert cue.node_name == "unknown"
+
+    def test_custom_voice(self):
+        cue = TTSCue(entity_name="Witch", text="Cursed be thou.", voice_id="en-GB-LibbyNeural")
+        assert cue.voice_id == "en-GB-LibbyNeural"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SFXCue
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSFXCue:
+    def test_defaults(self):
+        cue = SFXCue(sfx_key="door_slam")
+        assert cue.volume == pytest.approx(0.7)
+        assert cue.delay_ms == 0
+        assert cue.source == "vault"
+
+    def test_volume_validation(self):
+        with pytest.raises(ValidationError):
+            SFXCue(sfx_key="x", volume=1.5)
+
+    def test_negative_delay_rejected(self):
+        with pytest.raises(ValidationError):
+            SFXCue(sfx_key="x", delay_ms=-1)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MusicCue
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestMusicCue:
+    def test_defaults(self):
+        cue = MusicCue(scene_type="tavern", music_prompt="warm lute melody")
+        assert cue.volume == pytest.approx(0.45)
+        assert cue.crossfade_s == pytest.approx(2.0)
+        assert cue.audio_url == ""
+        assert cue.lavalink_query == ""
+
+    def test_volume_out_of_range_rejected(self):
+        with pytest.raises(ValidationError):
+            MusicCue(scene_type="combat", music_prompt="drums", volume=2.0)
+
+    def test_crossfade_upper_bound(self):
+        with pytest.raises(ValidationError):
+            MusicCue(scene_type="combat", music_prompt="drums", crossfade_s=11.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SubAgentTask / SubAgentResult
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSubAgentTask:
+    def test_auto_task_id_generated(self):
+        task = SubAgentTask(
+            task_type="npc_dialogue",
+            entity_name="Guard",
+            entity_role="city watchman",
+            scene_context="Night patrol at the gates.",
+            player_action_context="Player demands entry.",
+        )
+        assert len(task.task_id) > 0
+
+    def test_default_tone_is_gritty(self):
+        task = SubAgentTask(
+            task_type="npc_dialogue",
+            entity_name="Guard",
+            entity_role="watchman",
+            scene_context="Night.",
+            player_action_context="Entry demand.",
+        )
+        assert task.tone == "gritty"
+
+    def test_max_words_default_80(self):
+        task = SubAgentTask(
+            task_type="combat_flavour",
+            entity_name="Dagger",
+            entity_role="weapon",
+            scene_context="Battle.",
+            player_action_context="Stab.",
+        )
+        assert task.max_words == 80
+
+    def test_max_words_too_low_rejected(self):
+        with pytest.raises(ValidationError):
+            SubAgentTask(
+                task_type="npc_dialogue",
+                entity_name="x",
+                entity_role="y",
+                scene_context="z",
+                player_action_context="a",
+                max_words=5,
+            )
+
+
+class TestSubAgentResult:
+    def _make_task(self):
+        return SubAgentTask(
+            task_type="npc_dialogue",
+            entity_name="NPC",
+            entity_role="villain",
+            scene_context="Confrontation.",
+            player_action_context="Accusation.",
+        )
+
+    def test_default_voice_id(self):
+        r = SubAgentResult(task=self._make_task(), raw_output="You dare defy me?")
+        assert r.voice_id == "en-US-GuyNeural"
+
+    def test_brand_violation_defaults_false(self):
+        r = SubAgentResult(task=self._make_task(), raw_output="text")
+        assert r.brand_violation is False
+
+    def test_ttft_ms_defaults_none(self):
+        r = SubAgentResult(task=self._make_task(), raw_output="text")
+        assert r.ttft_ms is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GMPlanResult
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGMPlanResult:
+    def test_defaults(self):
+        plan = GMPlanResult()
+        assert plan.sub_tasks == []
+        assert plan.direct_elements == []
+        assert plan.trigger_scene_image is False
+        assert plan.trigger_npc_portrait is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DowntimeSubmitRequest field constraints
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDowntimeSubmitRequest:
+    def _make(self, **kw):
+        defaults = dict(
+            player_id="p-001",
+            guild_id="g-001",
+            campaign_id="c-001",
+            description="Brew potions all night.",
+        )
+        defaults.update(kw)
+        return DowntimeSubmitRequest(**defaults)
+
+    def test_default_duration_is_8(self):
+        assert self._make().duration_hours == 8
+
+    def test_duration_below_1_rejected(self):
+        with pytest.raises(ValidationError):
+            self._make(duration_hours=0)
+
+    def test_duration_above_168_rejected(self):
+        with pytest.raises(ValidationError):
+            self._make(duration_hours=169)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GMDirectiveRequest field constraints
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGMDirectiveRequest:
+    def _make(self, **kw):
+        defaults = dict(
+            campaign_id="camp-001",
+            admin_id="admin-001",
+            directive_text="Have the innkeeper mention the masked figure.",
+        )
+        defaults.update(kw)
+        return GMDirectiveRequest(**defaults)
+
+    def test_default_priority_is_5(self):
+        assert self._make().priority == 5
+
+    def test_priority_below_1_rejected(self):
+        with pytest.raises(ValidationError):
+            self._make(priority=0)
+
+    def test_priority_above_10_rejected(self):
+        with pytest.raises(ValidationError):
+            self._make(priority=11)
+
+    def test_default_directive_type(self):
+        assert self._make().directive_type == DirectiveType.SCENE_DIRECTIVE
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RetconRequest / RetconResponse
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestRetconRequest:
+    def test_construction(self):
+        r = RetconRequest(intent_id="i-001", admin_id="a-001", reason="Bad dice outcome")
+        assert r.intent_id == "i-001"
+        assert r.reason == "Bad dice outcome"
+
+    def test_reason_defaults_empty(self):
+        r = RetconRequest(intent_id="i-001", admin_id="a-001")
+        assert r.reason == ""
+
+
+class TestRetconResponse:
+    def test_construction(self):
+        r = RetconResponse(
+            intent_id="i-001",
+            character_id="c-001",
+            restored_stats={"hp": 20},
+        )
+        assert r.restored_stats["hp"] == 20
+        assert isinstance(r.retconned_at, datetime)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ChannelDirective
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestChannelDirective:
+    def test_move_to_construction(self):
+        cd = ChannelDirective(action="move_to", channel_key="prison")
+        assert cd.action == "move_to"
+        assert cd.channel_key == "prison"
+
+    def test_reason_defaults_empty(self):
+        cd = ChannelDirective(action="restore", channel_key="main")
+        assert cd.reason == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# StoryFact / ExtractedFact / ExtractionResult
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestStoryFact:
+    def test_construction(self):
+        sf = StoryFact(
+            fact_id="f-001",
+            entity_type=StoryEntityType.NPC,
+            entity_name="Mordecai the Blind",
+            summary="Mordecai is a retired assassin living in the market district.",
+            relevance=0.9,
+            established_at=datetime.utcnow(),
+        )
+        assert sf.entity_name == "Mordecai the Blind"
+        assert sf.relevance == pytest.approx(0.9)
+
+    def test_detail_defaults_empty(self):
+        sf = StoryFact(
+            fact_id="f-002",
+            entity_type=StoryEntityType.LOCATION,
+            entity_name="The Black Gate",
+            summary="A ruined fortress at the edge of the wastes.",
+            established_at=datetime.utcnow(),
+        )
+        assert sf.detail == ""
+
+    def test_relevance_out_of_range_rejected(self):
+        with pytest.raises(ValidationError):
+            StoryFact(
+                fact_id="f-003",
+                entity_type=StoryEntityType.EVENT,
+                entity_name="Battle",
+                summary="A great battle occurred.",
+                relevance=1.5,
+                established_at=datetime.utcnow(),
+            )
+
+
+class TestExtractionResult:
+    def test_empty_by_default(self):
+        er = ExtractionResult()
+        assert er.facts == []
+
+    def test_facts_stored(self):
+        ef = ExtractedFact(
+            entity_type=StoryEntityType.NPC,
+            entity_name="Lyra",
+            summary="Lyra is a spy for the crown.",
+        )
+        er = ExtractionResult(facts=[ef])
+        assert len(er.facts) == 1
+        assert er.facts[0].entity_name == "Lyra"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RuleChunk relevance validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestRuleChunk:
+    def test_valid_relevance(self):
+        rc = RuleChunk(
+            chunk_id="c-001",
+            source="PHB p.194",
+            content="Melee attack rules...",
+            relevance=0.85,
+        )
+        assert rc.relevance == pytest.approx(0.85)
+
+    def test_relevance_above_1_rejected(self):
+        with pytest.raises(ValidationError):
+            RuleChunk(
+                chunk_id="c-002",
+                source="PHB",
+                content="text",
+                relevance=1.01,
+            )
+
+    def test_relevance_below_0_rejected(self):
+        with pytest.raises(ValidationError):
+            RuleChunk(
+                chunk_id="c-003",
+                source="PHB",
+                content="text",
+                relevance=-0.1,
+            )


### PR DESCRIPTION
## Summary

- Adds `orchestrator/tests/` package (`__init__.py`) with 4 new test modules covering the remaining pure-logic modules that had no tests (~290 tests total, zero live-service dependencies)
- Continues the systematic test coverage effort from PRs #68–#78

## Test modules added

| Module | File | Tests |
|--------|------|-------|
| `orchestrator/prompts/guardrails.py` | `test_prompts_guardrails.py` | ~33 |
| `orchestrator/prompts/gm_prompts.py` | `test_prompts_gm.py` | ~80 |
| `orchestrator/prompts/immersion_prompts.py` | `test_prompts_immersion.py` | ~75 |
| `orchestrator/schemas/payloads.py` | `test_schemas_payloads.py` | ~100 |

## What each module tests

**`test_prompts_guardrails.py`**
- `MECHANICAL_SYSTEM_PROMPT` constant integrity — all required lock names present (`ANTI-SYCOPHANCY LOCK`, `DICE SUPREMACY LOCK`, `NARRATIVE PROHIBITION`, `VEHICLE RULES`)
- `build_narrative_system_prompt` (Gemini path) — system name injection, story-context bullet formatting, world tone prepending, all 5 lock names verified, multiple/empty context handling
- `build_local_narrative_prompt` (local/uncensored path) — same coverage plus `UNCENSORED` mode grant present; verified to differ from Gemini path on that key

**`test_prompts_gm.py`**
- `STRUCTURAL_PATTERNS` — regex list matches `## headers`, `Chapter N`, `---`, numbered/bulleted lists; does not match plain prose
- `BRAND_BLOCKLIST` — 150+ entries; tech brands, social media, fast food, real-world IP all present; all strings non-empty
- `SUBAGENT_PROMPT_TEMPLATES` — all 6 task types present (`npc_dialogue`, `environmental_description`, `combat_flavour`, `item_description`, `sound_director`, `scene_describer`) and renderable
- Template rendering — `GM_PLANNING_PROMPT`, `GM_SYNTHESIS_PROMPT`, `GM_DIRECTIVE_BLOCK`, `GM_STAT_CHANGE_BLOCK`, all `SUBAGENT_*_PROMPT` templates accept their required format keys
- `MUSIC_SCENE_PROMPTS` — all 5 scenes (`combat`, `exploration`, `social`, `tension`, `rest`) present and non-empty

**`test_prompts_immersion.py`**
- `is_combat_action` — 17 combat keywords verified; non-combat returns False; case-insensitive
- `is_combat_end` — `DEAD` status path, action-type keywords (flee/escape/surrender/retreat/yield/disengage/death_save/fall_unconscious), reasoning-field keywords, `None` reasoning safety
- `detect_channel_directive` — capture/imprisoned → `move_to`/prison; dungeon/cell/pit → `move_to`/dungeon; escaped/freed/breaks free → `restore`/main; escape checked before capture; no keywords → `(None, None)`
- `build_thread_content` — emoji mapping (🌟✅⚡❌💀), stat delta sign formatting (+/-), inventory changes, DEAD status shown, reasoning truncated at 280 chars, citation cap at 3

**`test_schemas_payloads.py`**
- Enum completeness — `CommandType` (3), `CharacterStatus` (3), `ActionOutcome` (5), `MultimediaType` (3), `OperationalStatus` (3), `StoryEntityType` (5), `ThreadEvent` (2), `DirectiveType` (5)
- `OllamaResolutionPayload` — `reasoning_must_be_mechanical` validator: ≤500 chars stored as-is, >500 chars truncated to exactly 500; `difficulty ge=1` enforced
- `SFXCue` / `MusicCue` — volume >1.0 rejected, delay_ms <0 rejected, crossfade_s >10.0 rejected
- `DowntimeSubmitRequest` / `GMDirectiveRequest` / `RuleChunk` — field range constraints enforced
- `NarrativeResponsePayload` — all Task-4 optional fields present (whisper, thread_event, ambient_audio_key, tts_cues, sfx_cues, channel_directive, music_cue, driftnet_channel_id)

## Test plan

- [ ] `pytest orchestrator/tests/test_prompts_guardrails.py -v`
- [ ] `pytest orchestrator/tests/test_prompts_gm.py -v`
- [ ] `pytest orchestrator/tests/test_prompts_immersion.py -v`
- [ ] `pytest orchestrator/tests/test_schemas_payloads.py -v`
- [ ] All 4 pass with no live services, no env vars required

---
_Generated by [Claude Code](https://claude.ai/code/session_017PtsTKxUM5e5XbLaHjXPP7)_