### PR TITLE
chore(docker): multi-stage builds + .dockerignore for all Python services

### DIFF
--- a/.claude/scheduled-execution.log
+++ b/.claude/scheduled-execution.log
@@ -22,3 +22,9 @@
 [2026-08-08T00:00:03Z] [DISCOVERY COMPLETE] 19 issues evaluated; all have open PRs awaiting human merge. No unimplemented feature issues found.
 [2026-08-08T00:00:04Z] [INFO] Sole .github/ rule file is docker-optimization.md — applying Docker image optimization to project Dockerfiles.
 [2026-08-08T00:00:05Z] [PHASE 1/4] Creating feature branch claude/chore/docker-optimization
+[2026-08-08T00:01:00Z] [PHASE 2/4] Created docs/docker-optimization-solution.md
+[2026-08-08T00:01:30Z] [PHASE 3/4] Implementation complete — 5 Dockerfiles updated, 5 .dockerignore files added
+[2026-08-08T00:01:31Z] [PUSH] Code pushed to claude/chore/docker-optimization
+[2026-08-08T00:01:45Z] [PULL_REQUEST] PR #81 created — chore(docker): multi-stage builds + .dockerignore for all Python services
+[2026-08-08T00:02:00Z] [PHASE 4/4] PR #81 open, 0 CI check runs (no CI workflows in repo), 0 review comments — awaiting human merge
+[2026-08-08T00:02:01Z] [COMPLETE] Scheduled cycle done. All 19 feature issues have open PRs awaiting merge. Applied .github/docker-optimization.md guidance to all Python service Dockerfiles via PR #81.

--- a/.claude/scheduled-execution.log
+++ b/.claude/scheduled-execution.log
@@ -1,0 +1,24 @@
+[2026-08-08T00:00:00Z] [INFO] [STARTUP] Initialized scheduled agent for crashcart/rpg-bot
+[2026-08-08T00:00:01Z] [CONFIG] Loaded .github/docker-optimization.md — Docker image optimization guide (multi-stage builds, Alpine base images, .dockerignore, layer ordering)
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #6  enhancement,help-wanted  complete  PR #52 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #7  enhancement  complete  PR #53 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #8  enhancement  complete  PR #65 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #9  no-label  complete  PR #57 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #10 enhancement  complete  PR #58 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #11 enhancement  complete  PR #67 open (refreshed 2026-07-23)
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #12 no-label  complete  PR #49 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #13 enhancement  complete  PR #50 open (refreshed 2026-07-29)
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #14 enhancement  complete  PR #51 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #15 enhancement  complete  PR #56 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #16 enhancement  complete  PR #54 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #17 no-label  complete  PR #55 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #18 no-label  complete  PR #64 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #19 enhancement  complete  PR #48 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #21 no-label  complete  PR #59 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #22 no-label  complete  PR #62 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #23 no-label  complete  PR #63 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #24 no-label  complete  PR #60 open
+[2026-08-08T00:00:02Z] [DISCOVERY] Issue #25 enhancement  complete  PR #61 open
+[2026-08-08T00:00:03Z] [DISCOVERY COMPLETE] 19 issues evaluated; all have open PRs awaiting human merge. No unimplemented feature issues found.
+[2026-08-08T00:00:04Z] [INFO] Sole .github/ rule file is docker-optimization.md — applying Docker image optimization to project Dockerfiles.
+[2026-08-08T00:00:05Z] [PHASE 1/4] Creating feature branch claude/chore/docker-optimization

--- a/csv-sync/.dockerignore
+++ b/csv-sync/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.git/
+.github/
+.env
+.env.*
+*.md
+tests/
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/

--- a/csv-sync/Dockerfile
+++ b/csv-sync/Dockerfile
@@ -1,10 +1,14 @@
-FROM python:3.12-slim
-
-WORKDIR /app
-
+FROM python:3.12-slim AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --user --no-cache-dir -r requirements.txt
 
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=builder /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
 COPY . .
-
 CMD ["python", "worker.py"]

--- a/discord-bot/.dockerignore
+++ b/discord-bot/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.git/
+.github/
+.env
+.env.*
+*.md
+tests/
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/

--- a/discord-bot/Dockerfile
+++ b/discord-bot/Dockerfile
@@ -1,10 +1,14 @@
-FROM python:3.12-slim
-
-WORKDIR /app
-
+FROM python:3.12-slim AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --user --no-cache-dir -r requirements.txt
 
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=builder /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
 COPY . .
-
 CMD ["python", "bot.py"]

--- a/docs/docker-optimization-solution.md
+++ b/docs/docker-optimization-solution.md
@@ -1,0 +1,50 @@
+# Docker Image Optimization — Solution Summary
+
+**Branch:** `claude/chore/docker-optimization`
+**Guided by:** `.github/docker-optimization.md`
+
+## Changes
+
+Five Python services were updated with multi-stage builds and `.dockerignore` files.
+The `janitor/` service already uses `alpine:3.20` — no changes needed there.
+
+### Multi-stage builds (5 services)
+
+| Service | Base (before) | Runtime (after) | Builder |
+|---------|--------------|-----------------|---------|
+| `orchestrator` | `python:3.12-slim` | `python:3.12-slim` | `python:3.12-slim` + `build-essential` |
+| `discord-bot` | `python:3.12-slim` | `python:3.12-slim` | `python:3.12-slim` + `build-essential` |
+| `health-sentinel` | `python:3.12-slim` | **`python:3.12-alpine`** | `python:3.12-alpine` |
+| `media-proxy` | `python:3.12-slim` | `python:3.12-slim` | `python:3.12-slim` + `build-essential` |
+| `csv-sync` | `python:3.12-slim` | `python:3.12-slim` | `python:3.12-slim` + `build-essential` |
+
+**Pattern applied** (per `.github/docker-optimization.md` § Python example):
+```dockerfile
+FROM python:3.12-slim AS builder
+RUN apt-get install -y --no-install-recommends build-essential ...
+RUN pip install --user --no-cache-dir -r requirements.txt
+
+FROM python:3.12-slim
+COPY --from=builder /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
+COPY . .
+```
+
+### `.dockerignore` files (5 services)
+
+Added to: `orchestrator/`, `discord-bot/`, `health-sentinel/`, `media-proxy/`, `csv-sync/`
+
+Excludes: `__pycache__/`, `*.pyc`, `.git/`, `.env*`, `tests/`, `.pytest_cache/`, `*.md`, build artifacts.
+
+### Why `health-sentinel` uses Alpine
+
+`health-sentinel` depends only on `flask`, `redis`, and `gunicorn` — all pure-Python wheels
+with no native compilation required. Alpine (`python:3.12-alpine`, ~22 MB) vs slim
+(`python:3.12-slim`, ~130 MB) gives ~85% base-image reduction for this service.
+
+### Notes on `orchestrator`
+
+`orchestrator` keeps `curl` in the **runtime** stage (not the builder) because the
+`docker-compose.yml` health-check uses `curl http://localhost:8000/health`. Build
+tools (`build-essential`) are builder-only; `asyncpg`, `chromadb`, and `pymupdf` wheels
+may require compilation on non-amd64 targets.

--- a/health-sentinel/.dockerignore
+++ b/health-sentinel/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.git/
+.github/
+.env
+.env.*
+*.md
+tests/
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/

--- a/health-sentinel/Dockerfile
+++ b/health-sentinel/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.12-slim
-WORKDIR /app
+FROM python:3.12-alpine AS builder
+WORKDIR /build
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --user --no-cache-dir -r requirements.txt
+
+FROM python:3.12-alpine
+WORKDIR /app
+COPY --from=builder /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
 COPY app.py .
 EXPOSE 58291
 CMD ["gunicorn", "--bind", "0.0.0.0:58291", "--workers", "2", "--timeout", "10", "app:app"]

--- a/media-proxy/.dockerignore
+++ b/media-proxy/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.git/
+.github/
+.env
+.env.*
+*.md
+tests/
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -1,12 +1,15 @@
-FROM python:3.12-slim
-
-WORKDIR /app
-
+FROM python:3.12-slim AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --user --no-cache-dir -r requirements.txt
 
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=builder /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
 COPY . .
-
 EXPOSE 8001
-
 CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/orchestrator/.dockerignore
+++ b/orchestrator/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.git/
+.github/
+.env
+.env.*
+*.md
+tests/
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,16 +1,18 @@
+FROM python:3.12-slim AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
+COPY requirements.txt .
+RUN pip install --user --no-cache-dir -r requirements.txt
+
 FROM python:3.12-slim
-
-WORKDIR /app
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
-
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
+WORKDIR /app
+COPY --from=builder /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
 COPY . .
-
 EXPOSE 8000
-
 CMD ["uvicorn", "orchestrator.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary

Applies the Docker image optimization techniques documented in `.github/docker-optimization.md` to all five Python services in the stack.

- **Multi-stage builds** added to `orchestrator`, `discord-bot`, `media-proxy`, `csv-sync`, and `health-sentinel` — `build-essential` (and any other compile-time packages) are isolated to the builder stage and never shipped in the final runtime image
- **`health-sentinel` switched to `python:3.12-alpine`** — its three dependencies (`flask`, `redis`, `gunicorn`) are pure-Python wheels; Alpine reduces the base image from ~130 MB to ~22 MB (~85% reduction)
- **`.dockerignore` added to all five services** — excludes `__pycache__/`, `*.pyc`, `.git/`, `.env*`, `tests/`, `.pytest_cache/`, and build artifacts from the Docker build context

`janitor/` already uses `alpine:3.20` per TDR §4 — no changes needed there.

## Pattern applied (per `.github/docker-optimization.md` Python example)

```dockerfile
FROM python:3.12-slim AS builder
RUN apt-get install -y --no-install-recommends build-essential …
RUN pip install --user --no-cache-dir -r requirements.txt

FROM python:3.12-slim
COPY --from=builder /root/.local /root/.local
ENV PATH=/root/.local/bin:$PATH
COPY . .
```

## Notes

- `orchestrator` retains `curl` in the **runtime** stage (not the builder) because `docker-compose.yml` uses `curl http://localhost:8000/health` for its health-check
- `build-essential` is kept in the builder for `orchestrator`, `discord-bot`, `media-proxy`, and `csv-sync` to handle native-extension packages (`asyncpg`, `chromadb`, `pymupdf`, `uvloop`) on non-amd64 targets; on `linux/amd64` most of these are pre-built wheels, so the builder stage exits quickly

## Test plan

- [ ] `docker build -t test-orchestrator orchestrator/` completes without error
- [ ] `docker build -t test-discord discord-bot/` completes without error
- [ ] `docker build -t test-pulse health-sentinel/` completes without error
- [ ] `docker build -t test-media media-proxy/` completes without error
- [ ] `docker build -t test-csv csv-sync/` completes without error
- [ ] `docker compose up --build` starts all services cleanly
- [ ] `health-sentinel` (`pulse`) responds on `:58291`

---
_Generated by [Claude Code](https://claude.ai/code/session_016oWM84Vb3mPnZ8aHPrqp6X)_